### PR TITLE
Make crates `no_std`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,18 +177,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-json-abi"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459f98c6843f208856f338bfb25e65325467f7aff35dfeb0484d0a76e059134b"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-type-parser",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "alloy-network-primitives"
 version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,25 +345,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-sol-type-parser"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52db32fbd35a9c0c0e538b58b81ebbae08a51be029e7ad60e08b60481c2ec6c3"
-dependencies = [
- "serde",
- "winnow",
-]
-
-[[package]]
 name = "alloy-sol-types"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a285b46e3e0c177887028278f04cc8262b76fd3b8e0e20e93cea0a58c35f5ac5"
 dependencies = [
- "alloy-json-abi",
  "alloy-primitives",
  "alloy-sol-macro",
- "serde",
 ]
 
 [[package]]
@@ -2005,7 +1981,6 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.105",
@@ -2810,17 +2785,12 @@ dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
  "alloy-trie 0.9.1",
- "bytes",
  "derive_more",
  "itertools 0.14.0",
  "nybbles 0.4.3",
  "reth-primitives-traits",
  "revm-database",
- "serde",
- "serde_with",
 ]
 
 [[package]]
@@ -2915,12 +2885,10 @@ version = "7.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39a276ed142b4718dcf64bc9624f474373ed82ef20611025045c3fb23edbef9c"
 dependencies = [
- "alloy-eips",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
  "revm-state",
- "serde",
 ]
 
 [[package]]
@@ -2933,7 +2901,6 @@ dependencies = [
  "either",
  "revm-primitives",
  "revm-state",
- "serde",
 ]
 
 [[package]]

--- a/crates/mpt/Cargo.toml
+++ b/crates/mpt/Cargo.toml
@@ -10,10 +10,10 @@ workspace = true
 
 [dependencies]
 alloy-trie = { version = "0.8.0", default-features = false }
-alloy-rlp = { version = "0.3.8", features = ["arrayvec"] }
-alloy-primitives = { version = "1.3", features = ["map"] }
+alloy-rlp = { version = "0.3.8", default-features = false }
+alloy-primitives = { version = "1.3", default-features = false }
 
-arrayvec = "0.7"
+arrayvec = { version = "0.7", default-features = false }
 bincode = { version = "1.3", optional = true }
 rkyv = { version = "0.8", optional = true }
 serde = { version = "1.0", optional = true }

--- a/crates/mpt/src/lib.rs
+++ b/crates/mpt/src/lib.rs
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![no_std]
+
+extern crate alloc;
 
 mod mpt;
 

--- a/crates/mpt/src/mpt/children.rs
+++ b/crates/mpt/src/mpt/children.rs
@@ -16,7 +16,8 @@ use super::{
     memoize::Memoization,
     node::{Child, Node},
 };
-use std::slice::Iter;
+use core::slice::Iter;
+use alloc::boxed::Box;
 
 /// Implements a helper wrapper for the children of a Branch node.
 ///

--- a/crates/mpt/src/mpt/mod.rs
+++ b/crates/mpt/src/mpt/mod.rs
@@ -20,7 +20,8 @@ use children::Children;
 use memoize::{Cache, NoCache};
 use nibbles::NibbleSlice;
 use node::Node;
-use std::{cmp::PartialEq, fmt::Debug};
+use core::{cmp::PartialEq, fmt::Debug};
+use alloc::vec::Vec;
 
 mod children;
 
@@ -406,7 +407,8 @@ mod tests {
     use alloy_primitives::{b256, keccak256, Bytes, U256};
     use alloy_trie::HashBuilder;
     use children::Children;
-    use std::{borrow::Borrow, collections::BTreeMap};
+    use core::{borrow::Borrow};
+    use alloc::{collections::BTreeMap, vec, vec::Vec};
 
     const N: usize = 512;
 

--- a/crates/mpt/src/mpt/nibbles.rs
+++ b/crates/mpt/src/mpt/nibbles.rs
@@ -20,7 +20,7 @@
 
 use alloy_primitives::hex;
 use alloy_trie::Nibbles;
-use std::{fmt, ops::Deref};
+use core::{fmt, ops::Deref};
 
 /// A slice of bytes representing nibbles.
 #[derive(Clone, Copy)]

--- a/crates/mpt/src/mpt/node.rs
+++ b/crates/mpt/src/mpt/node.rs
@@ -19,7 +19,8 @@ use super::{
 };
 use alloy_primitives::{Bytes, B256};
 use alloy_trie::Nibbles;
-use std::mem;
+use core::mem;
+use alloc::boxed::Box;
 
 pub(super) type Child<M> = Box<Node<M>>;
 

--- a/crates/mpt/src/mpt/orphan.rs
+++ b/crates/mpt/src/mpt/orphan.rs
@@ -227,7 +227,7 @@ mod tests {
     use crate::Trie;
     use alloy_primitives::{Bytes, B256};
     use alloy_trie::{proof::ProofRetainer, HashBuilder, Nibbles};
-    use std::{borrow::Borrow, panic};
+    use core::{borrow::Borrow, panic};
 
     fn create_eip1186_proof<K, V>(
         key: K,

--- a/crates/mpt/src/mpt/rlp.rs
+++ b/crates/mpt/src/mpt/rlp.rs
@@ -25,7 +25,8 @@ use alloy_primitives::{
 use alloy_rlp::{BufMut, Decodable, Encodable, Header, PayloadView, EMPTY_STRING_CODE};
 use alloy_trie::{nodes::encode_path_leaf, Nibbles, EMPTY_ROOT_HASH};
 use arrayvec::ArrayVec;
-use std::fmt;
+use core::fmt;
+use alloc::{vec, vec::Vec};
 
 /// The length in bytes of an RLP-encoded digest, i.e. hash length + 1 byte for the RLP header.
 const DIGEST_RLP_LENGTH: usize = 1 + B256::len_bytes();
@@ -436,7 +437,7 @@ fn decode_path(buf: &mut &[u8]) -> alloy_rlp::Result<(Nibbles, bool)> {
 
 fn encode_list<B, T>(values: &[B]) -> Vec<u8>
 where
-    B: std::borrow::Borrow<T>,
+    B: core::borrow::Borrow<T>,
     T: ?Sized + Encodable,
 {
     let mut payload_length = 0;

--- a/crates/sparsestate/Cargo.toml
+++ b/crates/sparsestate/Cargo.toml
@@ -10,9 +10,9 @@ alloy-primitives = { version = "1.3.1", default-features = false }
 alloy-trie = { version = "0.9.1", default-features = false }
 alloy-rlp = { version = "0.3.10", default-features = false }
 
-reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.7.0" }
-reth-stateless = { git = "https://github.com/paradigmxyz/reth", tag = "v1.7.0" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.7.0" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.7.0", default-features = false }
+reth-stateless = { git = "https://github.com/paradigmxyz/reth", tag = "v1.7.0", default-features = false }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.7.0", default-features = false }
 
 revm-bytecode = { version = "6.2.2", default-features = false }
 

--- a/crates/sparsestate/src/lib.rs
+++ b/crates/sparsestate/src/lib.rs
@@ -1,6 +1,5 @@
 //! Provides an optimized sparse MPT implementation for the stateless validator guest program.
 #![allow(warnings)]
-
 // Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,11 +13,17 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![no_std]
 
-use core::marker::PhantomData;
-use std::{cell::RefCell, collections::hash_map::Entry};
+extern crate alloc;
 
-use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, U256, keccak256, map::B256Map};
+use alloc::vec::Vec;
+use core::{cell::RefCell, marker::PhantomData};
+
+use alloy_primitives::{
+    Address, B256, Bytes, KECCAK256_EMPTY, U256, keccak256,
+    map::{B256Map, hash_map::Entry},
+};
 use alloy_trie::{EMPTY_ROOT_HASH, TrieAccount};
 use mpt::CachedTrie;
 use reth_errors::ProviderError;
@@ -94,8 +99,7 @@ impl SparseState {
         self.storages
             .get_mut()
             .entry(hashed_address)
-            .insert_entry(RlpTrie::default())
-            .into_mut()
+            .or_insert(RlpTrie::default())
     }
 
     /// Returns a mutable version of the storage trie of the given account.


### PR DESCRIPTION
In order to compile `zkevm-benchmark-workload` with stock rust compiler.

I tried to not format at all, so the diff looks cleaner.
