### PR TITLE
Make crates `no_std`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
  "k256",
  "once_cell",
  "rand 0.8.5",
- "secp256k1 0.30.0",
+ "secp256k1",
  "serde",
  "serde_json",
  "serde_with",
@@ -127,8 +127,6 @@ dependencies = [
  "c-kzg",
  "derive_more",
  "either",
- "ethereum_ssz",
- "ethereum_ssz_derive",
  "serde",
  "serde_with",
  "sha2",
@@ -145,14 +143,9 @@ dependencies = [
  "alloy-eips",
  "alloy-hardforks",
  "alloy-primitives",
- "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "op-alloy-consensus 0.21.0",
- "op-alloy-rpc-types-engine",
- "op-revm",
  "revm",
  "thiserror",
 ]
@@ -182,18 +175,6 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "dyn-clone",
-]
-
-[[package]]
-name = "alloy-json-abi"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459f98c6843f208856f338bfb25e65325467f7aff35dfeb0484d0a76e059134b"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-type-parser",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -280,11 +261,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
  "derive_more",
- "ethereum_ssz",
- "ethereum_ssz_derive",
- "serde",
  "strum",
 ]
 
@@ -369,25 +346,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-sol-type-parser"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52db32fbd35a9c0c0e538b58b81ebbae08a51be029e7ad60e08b60481c2ec6c3"
-dependencies = [
- "serde",
- "winnow",
-]
-
-[[package]]
 name = "alloy-sol-types"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a285b46e3e0c177887028278f04cc8262b76fd3b8e0e20e93cea0a58c35f5ac5"
 dependencies = [
- "alloy-json-abi",
  "alloy-primitives",
  "alloy-sol-macro",
- "serde",
 ]
 
 [[package]]
@@ -470,7 +435,6 @@ checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
 dependencies = [
  "ark-ec",
  "ark-ff 0.5.0",
- "ark-r1cs-std",
  "ark-std 0.5.0",
 ]
 
@@ -637,35 +601,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-r1cs-std"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
-dependencies = [
- "ark-ec",
- "ark-ff 0.5.0",
- "ark-relations",
- "ark-std 0.5.0",
- "educe",
- "num-bigint",
- "num-integer",
- "num-traits",
- "tracing",
-]
-
-[[package]]
-name = "ark-relations"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
-dependencies = [
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,12 +716,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "az"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
 name = "base16ct"
@@ -1368,46 +1297,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethereum_serde_utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
-dependencies = [
- "alloy-primitives",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "ethereum_ssz"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
-dependencies = [
- "alloy-primitives",
- "ethereum_serde_utils",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz_derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.105",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,16 +1436,6 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "gmp-mpfr-sys"
-version = "1.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60f8970a75c006bb2f8ae79c6768a116dd215fa8346a87aed99bf9d82ca43394"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
-]
 
 [[package]]
 name = "group"
@@ -2111,7 +1990,6 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
- "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.105",
@@ -2167,50 +2045,6 @@ dependencies = [
  "serde",
  "serde_with",
  "thiserror",
-]
-
-[[package]]
-name = "op-alloy-consensus"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1fc8aa0e2f5b136d101630be009e4e6dbdd1f17bc3ce670f431511600d2930"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "derive_more",
- "thiserror",
-]
-
-[[package]]
-name = "op-alloy-rpc-types-engine"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "860edb8d5a8d54bbcdabcbd8642c45b974351ce4e10ed528dd4508eee2a43833"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-engine",
- "derive_more",
- "ethereum_ssz",
- "ethereum_ssz_derive",
- "op-alloy-consensus 0.21.0",
- "snap",
- "thiserror",
-]
-
-[[package]]
-name = "op-revm"
-version = "11.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d721c4c196273dd135ea5b823cd573ea8735cd3c5f2c19fcb91ee3af655351"
-dependencies = [
- "auto_impl",
- "revm",
- "serde",
 ]
 
 [[package]]
@@ -2651,7 +2485,7 @@ dependencies = [
  "alloy-trie 0.9.1",
  "bytes",
  "modular-bitfield",
- "op-alloy-consensus 0.20.0",
+ "op-alloy-consensus",
  "reth-codecs-derive",
  "reth-zstd-compressors",
  "serde",
@@ -2699,9 +2533,7 @@ source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
- "bytes",
  "reth-primitives-traits",
- "serde",
 ]
 
 [[package]]
@@ -2741,7 +2573,6 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "once_cell",
- "rustc-hash",
 ]
 
 [[package]]
@@ -2757,7 +2588,6 @@ dependencies = [
  "alloy-serde",
  "reth-codecs",
  "reth-primitives-traits",
- "reth-zstd-compressors",
  "serde",
  "serde_with",
 ]
@@ -2810,8 +2640,6 @@ dependencies = [
  "reth-primitives-traits",
  "reth-trie-common",
  "revm",
- "serde",
- "serde_with",
 ]
 
 [[package]]
@@ -2821,7 +2649,6 @@ source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "secp256k1 0.30.0",
  "serde_with",
  "thiserror",
  "url",
@@ -2843,12 +2670,12 @@ dependencies = [
  "bytes",
  "derive_more",
  "once_cell",
- "op-alloy-consensus 0.20.0",
+ "op-alloy-consensus",
  "reth-codecs",
  "revm-bytecode",
  "revm-primitives",
  "revm-state",
- "secp256k1 0.30.0",
+ "secp256k1",
  "serde",
  "serde_with",
  "thiserror",
@@ -2861,7 +2688,6 @@ source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a
 dependencies = [
  "alloy-primitives",
  "derive_more",
- "serde",
  "thiserror",
 ]
 
@@ -2883,9 +2709,7 @@ version = "1.8.2"
 source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-primitives",
- "bytes",
  "reth-trie-common",
- "serde",
 ]
 
 [[package]]
@@ -2899,7 +2723,6 @@ dependencies = [
  "alloy-rpc-types-debug",
  "alloy-trie 0.9.1",
  "itertools 0.14.0",
- "k256",
  "reth-chainspec",
  "reth-consensus",
  "reth-errors",
@@ -2972,17 +2795,12 @@ dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
  "alloy-trie 0.9.1",
- "bytes",
  "derive_more",
  "itertools 0.14.0",
  "nybbles 0.4.3",
  "reth-primitives-traits",
  "revm-database",
- "serde",
- "serde_with",
 ]
 
 [[package]]
@@ -3054,7 +2872,6 @@ dependencies = [
  "revm-database-interface",
  "revm-primitives",
  "revm-state",
- "serde",
 ]
 
 [[package]]
@@ -3070,7 +2887,6 @@ dependencies = [
  "revm-database-interface",
  "revm-primitives",
  "revm-state",
- "serde",
 ]
 
 [[package]]
@@ -3079,12 +2895,10 @@ version = "9.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdefd7f40835e992bab40a245124cb1243e6c7a1c4659798827c809a59b0fea9"
 dependencies = [
- "alloy-eips",
  "revm-bytecode",
  "revm-database-interface",
  "revm-primitives",
  "revm-state",
- "serde",
 ]
 
 [[package]]
@@ -3097,7 +2911,6 @@ dependencies = [
  "either",
  "revm-primitives",
  "revm-state",
- "serde",
 ]
 
 [[package]]
@@ -3116,7 +2929,6 @@ dependencies = [
  "revm-precompile",
  "revm-primitives",
  "revm-state",
- "serde",
 ]
 
 [[package]]
@@ -3133,8 +2945,6 @@ dependencies = [
  "revm-interpreter",
  "revm-primitives",
  "revm-state",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -3147,7 +2957,6 @@ dependencies = [
  "revm-context-interface",
  "revm-primitives",
  "revm-state",
- "serde",
 ]
 
 [[package]]
@@ -3163,14 +2972,11 @@ dependencies = [
  "ark-serialize 0.5.0",
  "arrayref",
  "aurora-engine-modexp",
- "c-kzg",
  "cfg-if",
  "k256",
  "p256",
  "revm-primitives",
  "ripemd",
- "rug",
- "secp256k1 0.31.1",
  "sha2",
 ]
 
@@ -3255,18 +3061,6 @@ checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rustc-hex",
-]
-
-[[package]]
-name = "rug"
-version = "1.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad2e973fe3c3214251a840a621812a4f40468da814b1a3d6947d433c2af11f"
-dependencies = [
- "az",
- "gmp-mpfr-sys",
- "libc",
- "libm",
 ]
 
 [[package]]
@@ -3416,19 +3210,8 @@ checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.5",
- "secp256k1-sys 0.10.1",
+ "secp256k1-sys",
  "serde",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
-dependencies = [
- "bitcoin_hashes",
- "rand 0.9.2",
- "secp256k1-sys 0.11.0",
 ]
 
 [[package]]
@@ -3436,15 +3219,6 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
@@ -3509,7 +3283,6 @@ version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
- "indexmap 2.10.0",
  "itoa",
  "memchr",
  "ryu",
@@ -3625,12 +3398,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "snap"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "sparsestate"
@@ -3883,19 +3650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.105",
 ]
 
 [[package]]
@@ -3905,16 +3660,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
- "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,15 +131,15 @@ dependencies = [
  "ethereum_ssz_derive",
  "serde",
  "serde_with",
- "sha2 0.10.9",
+ "sha2",
  "thiserror",
 ]
 
 [[package]]
 name = "alloy-evm"
-version = "0.21.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a5f67ee74999aa4fe576a83be1996bdf74a30fce3d248bf2007d6fc7dae8aa"
+checksum = "dbb19405755c6f94c9bb856f2b1449767074b7e2002e1ab2be0a79b9b28db322"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -150,7 +150,7 @@ dependencies = [
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.21.0",
  "op-alloy-rpc-types-engine",
  "op-revm",
  "revm",
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "889eb3949b58368a09d4f16931c660275ef5fb08e5fbd4a96573b19c7085c41f"
+checksum = "4b16ee6b2c7d39da592d30a5f9607a83f50ee5ec2a2c301746cc81e91891f4ca"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -848,9 +848,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 dependencies = [
  "serde",
 ]
@@ -866,15 +866,6 @@ dependencies = [
  "serde",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -950,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.1"
+version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7318cfa722931cb5fe0838b98d3ce5621e75f6a6408abc21721d80de9223f2e4"
+checksum = "e00bf4b112b07b505472dbefd19e37e53307e2bfed5a79e0cc161d58ccd0e687"
 dependencies = [
  "blst",
  "cc",
@@ -1255,7 +1246,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -1885,7 +1876,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -1924,52 +1915,6 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
-
-[[package]]
-name = "libsecp256k1"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79019718125edc905a079a70cfa5f3820bc76139fc91d6f9abc27ea2a887139"
-dependencies = [
- "arrayref",
- "base64",
- "digest 0.9.0",
- "libsecp256k1-core",
- "libsecp256k1-gen-ecmult",
- "libsecp256k1-gen-genmult",
- "rand 0.8.5",
- "serde",
- "sha2 0.9.9",
-]
-
-[[package]]
-name = "libsecp256k1-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
-dependencies = [
- "crunchy",
- "digest 0.9.0",
- "subtle",
-]
-
-[[package]]
-name = "libsecp256k1-gen-ecmult"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
-dependencies = [
- "libsecp256k1-core",
-]
-
-[[package]]
-name = "libsecp256k1-gen-genmult"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
-dependencies = [
- "libsecp256k1-core",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2225,10 +2170,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "op-alloy-rpc-types-engine"
-version = "0.20.0"
+name = "op-alloy-consensus"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14e50c94013a1d036a529df259151991dbbd6cf8dc215e3b68b784f95eec60e6"
+checksum = "cf1fc8aa0e2f5b136d101630be009e4e6dbdd1f17bc3ce670f431511600d2930"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more",
+ "thiserror",
+]
+
+[[package]]
+name = "op-alloy-rpc-types-engine"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "860edb8d5a8d54bbcdabcbd8642c45b974351ce4e10ed528dd4508eee2a43833"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2238,27 +2197,21 @@ dependencies = [
  "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.21.0",
  "snap",
  "thiserror",
 ]
 
 [[package]]
 name = "op-revm"
-version = "10.1.1"
+version = "11.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826f43a5b1613c224f561847c152bfbaefcb593a9ae2c612ff4dc4661c6e625f"
+checksum = "b1d721c4c196273dd135ea5b823cd573ea8735cd3c5f2c19fcb91ee3af655351"
 dependencies = [
  "auto_impl",
  "revm",
  "serde",
 ]
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "p256"
@@ -2269,7 +2222,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -2325,9 +2278,9 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -2336,19 +2289,19 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
+ "fastrand",
  "phf_shared",
- "rand 0.8.5",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -2359,9 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -2669,7 +2622,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -2689,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2698,7 +2651,7 @@ dependencies = [
  "alloy-trie 0.9.1",
  "bytes",
  "modular-bitfield",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.20.0",
  "reth-codecs-derive",
  "reth-zstd-compressors",
  "serde",
@@ -2707,9 +2660,8 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
- "convert_case",
  "proc-macro2",
  "quote",
  "syn 2.0.105",
@@ -2718,7 +2670,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -2731,7 +2683,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2743,7 +2695,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -2755,7 +2707,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -2766,7 +2718,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2782,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -2795,7 +2747,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2813,7 +2765,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2834,7 +2786,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -2847,7 +2799,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2865,7 +2817,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -2878,7 +2830,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2891,7 +2843,7 @@ dependencies = [
  "bytes",
  "derive_more",
  "once_cell",
- "op-alloy-consensus",
+ "op-alloy-consensus 0.20.0",
  "reth-codecs",
  "revm-bytecode",
  "revm-primitives",
@@ -2905,7 +2857,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -2916,7 +2868,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -2928,7 +2880,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -2939,7 +2891,7 @@ dependencies = [
 [[package]]
 name = "reth-stateless"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -2947,6 +2899,7 @@ dependencies = [
  "alloy-rpc-types-debug",
  "alloy-trie 0.9.1",
  "itertools 0.14.0",
+ "k256",
  "reth-chainspec",
  "reth-consensus",
  "reth-errors",
@@ -2965,7 +2918,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -2976,7 +2929,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2998,7 +2951,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -3014,7 +2967,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -3035,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -3051,16 +3004,16 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.8.2#9c30bf7af5e0d45deaf5917375c9922c16654b28"
+source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "29.0.1"
+version = "30.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718d90dce5f07e115d0e66450b1b8aa29694c1cf3f89ebddaddccc2ccbd2f13e"
+checksum = "4fad790fa1836288df2698203f996e04f942b0eec69fc7f614f0386b78d9f8a5"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3077,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "6.2.2"
+version = "7.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c52031b73cae95d84cd1b07725808b5fd1500da3e5e24574a3b2dc13d9f16d"
+checksum = "451748b17ac78bd2b0748ec472a5392cd78fc0f7d19d528be44770fda28fd6f7"
 dependencies = [
  "bitvec",
  "phf",
@@ -3089,9 +3042,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "9.1.0"
+version = "10.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a20c98e7008591a6f012550c2a00aa36cba8c14cc88eb88dec32eb9102554b4"
+checksum = "7adcce0c14cf59b7128de34185a0fbf8f63309539b9263b35ead870d73584114"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3106,9 +3059,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "10.2.0"
+version = "11.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50d241ed1ce647b94caf174fcd0239b7651318b2c4c06b825b59b973dfb8495"
+checksum = "7d620a9725e443c171fb195a074331fa4a745fa5cbb0018b4bbf42619e64b563"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3122,9 +3075,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "7.0.5"
+version = "9.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a276ed142b4718dcf64bc9624f474373ed82ef20611025045c3fb23edbef9c"
+checksum = "fdefd7f40835e992bab40a245124cb1243e6c7a1c4659798827c809a59b0fea9"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -3136,9 +3089,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "7.0.5"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c523c77e74eeedbac5d6f7c092e3851dbe9c7fec6f418b85992bd79229db361"
+checksum = "aa488a73ac2738f11478650cdf1a0f263864c09d5f0e9bf6309e891a05323c60"
 dependencies = [
  "auto_impl",
  "either",
@@ -3149,9 +3102,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "10.0.1"
+version = "11.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550331ea85c1d257686e672081576172fe3d5a10526248b663bbf54f1bef226a"
+checksum = "54384bb0b081184c3ba3fc66e72781ff6ca5a8408067000f58255ab515b2fdb0"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -3168,9 +3121,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "10.0.1"
+version = "11.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0a6e9ccc2ae006f5bed8bd80cd6f8d3832cd55c5e861b9402fdd556098512f"
+checksum = "7c0ed01fe30ba5f5690115cbe531962bbbfc12603c695ceaddc28d457a646a05"
 dependencies = [
  "auto_impl",
  "either",
@@ -3186,21 +3139,22 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "25.0.3"
+version = "27.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06575dc51b1d8f5091daa12a435733a90b4a132dca7ccee0666c7db3851bc30c"
+checksum = "0834fc25c020061f0f801d8de8bb53c88a63631cca5884a6c65b90c85e241138"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
  "revm-primitives",
+ "revm-state",
  "serde",
 ]
 
 [[package]]
 name = "revm-precompile"
-version = "27.0.0"
+version = "28.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b57d4bd9e6b5fe469da5452a8a137bc2d030a3cd47c46908efc615bbc699da"
+checksum = "e57aadd7a2087705f653b5aaacc8ad4f8e851f5d330661e3f4c43b5475bbceae"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3212,20 +3166,19 @@ dependencies = [
  "c-kzg",
  "cfg-if",
  "k256",
- "libsecp256k1",
  "p256",
  "revm-primitives",
  "ripemd",
  "rug",
  "secp256k1 0.31.1",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "20.2.1"
+version = "21.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa29d9da06fe03b249b6419b33968ecdf92ad6428e2f012dc57bcd619b5d94e"
+checksum = "536f30e24c3c2bf0d3d7d20fa9cf99b93040ed0f021fd9301c78cddb0dacda13"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -3235,9 +3188,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "7.0.5"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f64fbacb86008394aaebd3454f9643b7d5a782bd251135e17c5b33da592d84d"
+checksum = "9e6bd5e669b02007872a8ca2643a14e308fe1739ee4475d74122587c3388a06a"
 dependencies = [
  "bitflags",
  "revm-bytecode",
@@ -3603,19 +3556,6 @@ checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct",
  "serde",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
 ]
 
 [[package]]

--- a/crates/mpt/Cargo.toml
+++ b/crates/mpt/Cargo.toml
@@ -10,10 +10,10 @@ workspace = true
 
 [dependencies]
 alloy-trie = { version = "0.8.0", default-features = false }
-alloy-rlp = { version = "0.3.8", features = ["arrayvec"] }
-alloy-primitives = { version = "1.3", features = ["map"] }
+alloy-rlp = { version = "0.3.8", default-features = false }
+alloy-primitives = { version = "1.3", default-features = false }
 
-arrayvec = "0.7"
+arrayvec = { version = "0.7", default-features = false }
 bincode = { version = "1.3", optional = true }
 rkyv = { version = "0.8", optional = true }
 serde = { version = "1.0", optional = true }

--- a/crates/mpt/src/lib.rs
+++ b/crates/mpt/src/lib.rs
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![no_std]
+
+extern crate alloc;
 
 mod mpt;
 

--- a/crates/mpt/src/mpt/children.rs
+++ b/crates/mpt/src/mpt/children.rs
@@ -16,7 +16,8 @@ use super::{
     memoize::Memoization,
     node::{Child, Node},
 };
-use std::slice::Iter;
+use core::slice::Iter;
+use alloc::boxed::Box;
 
 /// Implements a helper wrapper for the children of a Branch node.
 ///

--- a/crates/mpt/src/mpt/mod.rs
+++ b/crates/mpt/src/mpt/mod.rs
@@ -20,7 +20,8 @@ use children::Children;
 use memoize::{Cache, NoCache};
 use nibbles::NibbleSlice;
 use node::Node;
-use std::{cmp::PartialEq, fmt::Debug};
+use core::{cmp::PartialEq, fmt::Debug};
+use alloc::vec::Vec;
 
 mod children;
 
@@ -406,7 +407,8 @@ mod tests {
     use alloy_primitives::{b256, keccak256, Bytes, U256};
     use alloy_trie::HashBuilder;
     use children::Children;
-    use std::{borrow::Borrow, collections::BTreeMap};
+    use core::{borrow::Borrow};
+    use alloc::{collections::BTreeMap, vec, vec::Vec};
 
     const N: usize = 512;
 

--- a/crates/mpt/src/mpt/nibbles.rs
+++ b/crates/mpt/src/mpt/nibbles.rs
@@ -20,7 +20,7 @@
 
 use alloy_primitives::hex;
 use alloy_trie::Nibbles;
-use std::{fmt, ops::Deref};
+use core::{fmt, ops::Deref};
 
 /// A slice of bytes representing nibbles.
 #[derive(Clone, Copy)]

--- a/crates/mpt/src/mpt/node.rs
+++ b/crates/mpt/src/mpt/node.rs
@@ -19,7 +19,8 @@ use super::{
 };
 use alloy_primitives::{Bytes, B256};
 use alloy_trie::Nibbles;
-use std::mem;
+use core::mem;
+use alloc::boxed::Box;
 
 pub(super) type Child<M> = Box<Node<M>>;
 

--- a/crates/mpt/src/mpt/orphan.rs
+++ b/crates/mpt/src/mpt/orphan.rs
@@ -227,7 +227,7 @@ mod tests {
     use crate::Trie;
     use alloy_primitives::{Bytes, B256};
     use alloy_trie::{proof::ProofRetainer, HashBuilder, Nibbles};
-    use std::{borrow::Borrow, panic};
+    use core::{borrow::Borrow, panic};
 
     fn create_eip1186_proof<K, V>(
         key: K,

--- a/crates/mpt/src/mpt/rlp.rs
+++ b/crates/mpt/src/mpt/rlp.rs
@@ -25,7 +25,8 @@ use alloy_primitives::{
 use alloy_rlp::{BufMut, Decodable, Encodable, Header, PayloadView, EMPTY_STRING_CODE};
 use alloy_trie::{nodes::encode_path_leaf, Nibbles, EMPTY_ROOT_HASH};
 use arrayvec::ArrayVec;
-use std::fmt;
+use core::fmt;
+use alloc::{vec, vec::Vec};
 
 /// The length in bytes of an RLP-encoded digest, i.e. hash length + 1 byte for the RLP header.
 const DIGEST_RLP_LENGTH: usize = 1 + B256::len_bytes();
@@ -436,7 +437,7 @@ fn decode_path(buf: &mut &[u8]) -> alloy_rlp::Result<(Nibbles, bool)> {
 
 fn encode_list<B, T>(values: &[B]) -> Vec<u8>
 where
-    B: std::borrow::Borrow<T>,
+    B: core::borrow::Borrow<T>,
     T: ?Sized + Encodable,
 {
     let mut payload_length = 0;

--- a/crates/sparsestate/Cargo.toml
+++ b/crates/sparsestate/Cargo.toml
@@ -10,10 +10,10 @@ alloy-primitives = { version = "1.4.1", default-features = false }
 alloy-trie = { version = "0.9.1", default-features = false }
 alloy-rlp = { version = "0.3.10", default-features = false }
 
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "e969262c7ec48f073b8ea7920a75161e7130a98e" }
-reth-stateless = { git = "https://github.com/paradigmxyz/reth", rev = "e969262c7ec48f073b8ea7920a75161e7130a98e" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "e969262c7ec48f073b8ea7920a75161e7130a98e" }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "e969262c7ec48f073b8ea7920a75161e7130a98e" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "e969262c7ec48f073b8ea7920a75161e7130a98e", default-features = false }
+reth-stateless = { git = "https://github.com/paradigmxyz/reth", rev = "e969262c7ec48f073b8ea7920a75161e7130a98e", default-features = false }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "e969262c7ec48f073b8ea7920a75161e7130a98e", default-features = false }
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "e969262c7ec48f073b8ea7920a75161e7130a98e", default-features = false }
 
 mpt = { path = "../mpt" }
 

--- a/crates/sparsestate/src/lib.rs
+++ b/crates/sparsestate/src/lib.rs
@@ -1,6 +1,5 @@
 //! Provides an optimized sparse MPT implementation for the stateless validator guest program.
 #![allow(warnings)]
-
 // Copyright 2025 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,11 +13,17 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![no_std]
 
-use core::marker::PhantomData;
-use std::{cell::RefCell, collections::hash_map::Entry};
+extern crate alloc;
 
-use alloy_primitives::{Address, B256, Bytes, KECCAK256_EMPTY, U256, keccak256, map::B256Map};
+use alloc::vec::Vec;
+use core::{cell::RefCell, marker::PhantomData};
+
+use alloy_primitives::{
+    Address, B256, Bytes, KECCAK256_EMPTY, U256, keccak256,
+    map::{B256Map, hash_map::Entry},
+};
 use alloy_trie::{EMPTY_ROOT_HASH, TrieAccount};
 use mpt::CachedTrie;
 use reth_errors::ProviderError;
@@ -91,11 +96,14 @@ impl SparseState {
 
     /// Clears the storage of an account.
     fn clear_storage(&mut self, hashed_address: B256) -> &mut RlpTrie<U256> {
-        self.storages
-            .get_mut()
-            .entry(hashed_address)
-            .insert_entry(RlpTrie::default())
-            .into_mut()
+        match self.storages.get_mut().entry(hashed_address) {
+            Entry::Occupied(mut entry) => {
+                entry.insert(RlpTrie::default());
+                entry
+            }
+            Entry::Vacant(entry) => entry.insert_entry(RlpTrie::default()),
+        }
+        .into_mut()
     }
 
     /// Returns a mutable version of the storage trie of the given account.


### PR DESCRIPTION
In order to compile zkevm-benchmark-workload with stock rust compiler.

I tried to not format at all, so the diff looks cleaner.