### PR TITLE
Simple MPT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.6"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4195a29a4b87137b2bb02105e746102873bc03561805cf45c0e510c961f160e6"
+checksum = "4bc32535569185cbcb6ad5fa64d989a47bccb9a08e27284b1f2a3ccf16e6d010"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -35,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.38"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a0dd3ed764953a6b20458b2b7abbfdc93d20d14b38babe1a70fe631a443a9f1"
+checksum = "8b6440213a22df93a87ed512d2f668e7dc1d62a05642d107f82d61edc9e12370"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -46,6 +46,7 @@ dependencies = [
  "alloy-trie 0.9.1",
  "alloy-tx-macros",
  "auto_impl",
+ "borsh",
  "c-kzg",
  "derive_more",
  "either",
@@ -61,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.38"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9556182afa73cddffa91e64a5aa9508d5e8c912b3a15f26998d2388a824d2c7b"
+checksum = "15d0bea09287942405c4f9d2a4f22d1e07611c2dbd9d5bf94b75366340f9e6e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -88,23 +89,25 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip2930"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
+checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "borsh",
  "serde",
 ]
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
+checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "borsh",
  "k256",
  "serde",
  "serde_with",
@@ -113,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.38"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305fa99b538ca7006b0c03cfed24ec6d82beda67aac857ef4714be24231d15e6"
+checksum = "4bd2c7ae05abcab4483ce821f12f285e01c0b33804e6883dd9ca1569a87ee2be"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -124,6 +127,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "auto_impl",
+ "borsh",
  "c-kzg",
  "derive_more",
  "either",
@@ -135,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.22.3"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb19405755c6f94c9bb856f2b1449767074b7e2002e1ab2be0a79b9b28db322"
+checksum = "08e9e656d58027542447c1ca5aa4ca96293f09e6920c4651953b7451a7c35e4e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -152,23 +156,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.38"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a272533715aefc900f89d51db00c96e6fd4f517ea081a12fea482a352c8c815c"
+checksum = "fc47eaae86488b07ea8e20236184944072a78784a1f4993f8ec17b3aa5d08c21"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-serde",
  "alloy-trie 0.9.1",
+ "borsh",
  "serde",
  "serde_with",
 ]
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.4.0"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b16ee6b2c7d39da592d30a5f9607a83f50ee5ec2a2c301746cc81e91891f4ca"
+checksum = "1e29d7eacf42f89c21d7f089916d0bdb4f36139a31698790e8837d2dbbd4b2c3"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -179,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.38"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223612259a080160ce839a4e5df0125ca403a1d5e7206cc911cea54af5d769aa"
+checksum = "7805124ad69e57bbae7731c9c344571700b2a18d351bda9e0eba521c991d1bcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -202,8 +207,8 @@ dependencies = [
  "const-hex",
  "derive_more",
  "foldhash",
- "hashbrown 0.16.0",
- "indexmap 2.10.0",
+ "hashbrown 0.16.1",
+ "indexmap 2.12.1",
  "itoa",
  "k256",
  "keccak-asm",
@@ -236,14 +241,14 @@ checksum = "64b728d511962dda67c1bc7ea7c03736ec275ed2cf4c35d9585298ac9ccf3b73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "1.0.38"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ac29dd005c33e3f7e09087accc80843315303685c3f7a1b888002cd27785b"
+checksum = "1b2ca3a434a6d49910a7e8e51797eb25db42ef8a5578c52d877fcb26d0afe7bc"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -253,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "1.0.38"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9d173854879bcf26c7d71c1c3911972a3314df526f4349ffe488e676af577d"
+checksum = "d9c4c53a8b0905d931e7921774a1830609713bd3e8222347963172b03a3ecc68"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -267,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.38"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7d47bca1a2a1541e4404aa38b7e262bb4dffd9ac23b4f178729a4ddc5a5caa"
+checksum = "ed5fafb741c19b3cca4cdd04fa215c89413491f9695a3e928dee2ae5657f607e"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -288,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.38"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8468f1a7f9ee3bae73c24eead0239abea720dbf7779384b9c7e20d51bfb6b0"
+checksum = "a6f180c399ca7c1e2fe17ea58343910cad0090878a696ff5a50241aee12fc529"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -299,41 +304,41 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedac07a10d4c2027817a43cc1f038313fc53c7ac866f7363239971fd01f9f18"
+checksum = "f3ce480400051b5217f19d6e9a82d9010cdde20f1ae9c00d53591e4a1afbb312"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f9a598f010f048d8b8226492b6401104f5a5c1273c2869b72af29b48bb4ba9"
+checksum = "6d792e205ed3b72f795a8044c52877d2e6b6e9b1d13f431478121d8d4eaa9028"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.10.0",
+ "indexmap 2.12.1",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
  "syn-solidity",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f494adf9d60e49aa6ce26dfd42c7417aa6d4343cf2ae621f20e4d92a5ad07d85"
+checksum = "0bd1247a8f90b465ef3f1207627547ec16940c35597875cdc09c49d58b19693c"
 dependencies = [
  "const-hex",
  "dunce",
@@ -341,15 +346,15 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a285b46e3e0c177887028278f04cc8262b76fd3b8e0e20e93cea0a58c35f5ac5"
+checksum = "70319350969a3af119da6fb3e9bddb1bce66c9ea933600cb297c8b1850ad2a3c"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-macro",
@@ -381,7 +386,7 @@ dependencies = [
  "alloy-rlp",
  "arrayvec",
  "derive_more",
- "nybbles 0.4.3",
+ "nybbles 0.4.6",
  "serde",
  "smallvec",
  "tracing",
@@ -389,22 +394,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.38"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bf39928a5e70c9755d6811a2928131b53ba785ad37c8bf85c90175b5d43b818"
+checksum = "ae109e33814b49fc0a62f2528993aa8a2dd346c26959b151f05441dc0b9da292"
 dependencies = [
- "alloy-primitives",
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -544,7 +542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -582,7 +580,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -642,7 +640,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -708,7 +706,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -777,11 +775,11 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -808,14 +806,37 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fd49896f12ac9b6dcd7a5998466b9b58263a695a3dd1ecc1aaca2e12a90b080"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
 dependencies = [
  "cc",
  "glob",
  "threadpool",
  "zeroize",
+]
+
+[[package]]
+name = "borsh"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -832,9 +853,9 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytecheck"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50690fb3370fb9fe3550372746084c46f2ac8c9685c583d2be10eefd89d3d1a3"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
@@ -844,13 +865,13 @@ dependencies = [
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb7846e0cb180355c2dec69e721edafa36919850f1a9f52ffba4ebc0393cb71"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -861,9 +882,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 dependencies = [
  "serde",
 ]
@@ -885,10 +906,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.32"
+version = "1.2.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
+checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -896,17 +918,22 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
@@ -915,15 +942,14 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.14.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e22e0ed40b96a48d3db274f72fd365bd78f67af39b6bbd47e8a15e1c6207ff"
+checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "hex",
  "proptest",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -934,9 +960,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const_format"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
 dependencies = [
  "const_format_proc_macros",
 ]
@@ -978,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
 dependencies = [
  "crc-catalog",
 ]
@@ -1027,36 +1053,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.105",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1071,18 +1073,7 @@ dependencies = [
  "quote",
  "serde",
  "strsim",
- "syn 2.0.105",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1091,9 +1082,9 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1108,12 +1099,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1135,7 +1126,7 @@ checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1156,7 +1147,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
  "unicode-xid",
 ]
 
@@ -1189,7 +1180,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1228,7 +1219,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1262,22 +1253,22 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.3.0"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.3.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1288,12 +1279,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1335,6 +1326,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,9 +1357,9 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -1399,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -1416,19 +1413,19 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasip2",
 ]
 
 [[package]]
@@ -1465,12 +1462,13 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "foldhash",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1490,15 +1488,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "hex-conservative"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
 dependencies = [
  "arrayvec",
 ]
@@ -1514,9 +1509,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1538,9 +1533,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1551,9 +1546,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1564,11 +1559,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -1579,42 +1573,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -1630,9 +1620,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -1666,7 +1656,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1682,13 +1672,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1726,19 +1717,19 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1778,16 +1769,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libm"
@@ -1797,21 +1782,21 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "macro-string"
@@ -1821,14 +1806,14 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "modular-bitfield"
@@ -1866,22 +1851,22 @@ dependencies = [
 
 [[package]]
 name = "munge"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7feb0b48aa0a25f9fe0899482c6e1379ee7a11b24a53073eacdecb9adb6dc60"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
 dependencies = [
  "munge_macro",
 ]
 
 [[package]]
 name = "munge_macro"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2e3795a5d2da581a8b252fec6022eee01aea10161a4d1bf237d4cbe47f7e988"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1976,9 +1961,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -1986,13 +1971,13 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2008,9 +1993,9 @@ dependencies = [
 
 [[package]]
 name = "nybbles"
-version = "0.4.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63cb50036b1ad148038105af40aaa70ff24d8a14fbc44ae5c914e1348533d12e"
+checksum = "2c4b5ecbd0beec843101bffe848217f770e8b8da81d8355b7d6e226f2199b3dc"
 dependencies = [
  "alloy-rlp",
  "cfg-if",
@@ -2084,7 +2069,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2095,18 +2080,17 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.1"
+version = "2.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+checksum = "cbcfd20a6d4eeba40179f05735784ad32bdaef05ce8e8af05f180d45bb3e7e22"
 dependencies = [
  "memchr",
- "thiserror",
  "ucd-trie",
 ]
 
@@ -2141,7 +2125,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2189,9 +2173,9 @@ checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -2233,9 +2217,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
 ]
@@ -2259,28 +2243,27 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.97"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
+checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
  "bit-set",
  "bit-vec",
  "bitflags",
- "lazy_static",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -2293,22 +2276,22 @@ dependencies = [
 
 [[package]]
 name = "ptr_meta"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9e76f66d3f9606f44e45598d155cb13ecf09f4a28199e48daf8c8fc937ea90"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
 dependencies = [
  "ptr_meta_derive",
 ]
 
 [[package]]
 name = "ptr_meta_derive"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2319,9 +2302,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -2340,9 +2323,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rancor"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf5f7161924b9d1cea0e4cabc97c372cea92b5f927fc13c6bca67157a0ad947"
+checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
 dependencies = [
  "ptr_meta",
 ]
@@ -2405,7 +2388,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "serde",
 ]
 
@@ -2420,35 +2403,35 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rend"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215"
+checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
 dependencies = [
  "bytecheck",
 ]
@@ -2456,7 +2439,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -2476,7 +2459,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2494,17 +2477,17 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "reth-consensus"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -2517,7 +2500,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2529,7 +2512,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -2539,7 +2522,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -2550,7 +2533,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2566,7 +2549,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -2578,7 +2561,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2595,7 +2578,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2616,12 +2599,12 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
- "nybbles 0.4.3",
+ "nybbles 0.4.6",
  "reth-storage-errors",
  "thiserror",
 ]
@@ -2629,7 +2612,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2645,7 +2628,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -2657,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2684,7 +2667,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -2694,7 +2677,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -2706,7 +2689,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-primitives",
  "reth-trie-common",
@@ -2715,9 +2698,10 @@ dependencies = [
 [[package]]
 name = "reth-stateless"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-consensus",
+ "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-debug",
@@ -2736,12 +2720,13 @@ dependencies = [
  "serde",
  "serde_with",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
 name = "reth-static-file-types"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -2752,7 +2737,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2774,7 +2759,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -2790,7 +2775,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -2798,7 +2783,7 @@ dependencies = [
  "alloy-trie 0.9.1",
  "derive_more",
  "itertools 0.14.0",
- "nybbles 0.4.3",
+ "nybbles 0.4.6",
  "reth-primitives-traits",
  "revm-database",
 ]
@@ -2806,7 +2791,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -2822,16 +2807,16 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.8.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=e969262c7ec48f073b8ea7920a75161e7130a98e#e969262c7ec48f073b8ea7920a75161e7130a98e"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "30.1.2"
+version = "30.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fad790fa1836288df2698203f996e04f942b0eec69fc7f614f0386b78d9f8a5"
+checksum = "76df793c6ef3bef8f88f05b3873ebebce1494385a3ce8f58ad2e2e111aa0de11"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -2848,9 +2833,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "7.0.2"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451748b17ac78bd2b0748ec472a5392cd78fc0f7d19d528be44770fda28fd6f7"
+checksum = "e2c6b5e6e8dd1e28a4a60e5f46615d4ef0809111c9e63208e55b5c7058200fb0"
 dependencies = [
  "bitvec",
  "phf",
@@ -2891,9 +2876,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "9.0.2"
+version = "9.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdefd7f40835e992bab40a245124cb1243e6c7a1c4659798827c809a59b0fea9"
+checksum = "980d8d6bba78c5dd35b83abbb6585b0b902eb25ea4448ed7bfba6283b0337191"
 dependencies = [
  "revm-bytecode",
  "revm-database-interface",
@@ -2903,9 +2888,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "8.0.3"
+version = "8.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa488a73ac2738f11478650cdf1a0f263864c09d5f0e9bf6309e891a05323c60"
+checksum = "8cce03e3780287b07abe58faf4a7f5d8be7e81321f93ccf3343c8f7755602bae"
 dependencies = [
  "auto_impl",
  "either",
@@ -2915,9 +2900,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "11.1.2"
+version = "11.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54384bb0b081184c3ba3fc66e72781ff6ca5a8408067000f58255ab515b2fdb0"
+checksum = "b1d8049b2fbff6636150f4740c95369aa174e41b0383034e0e256cfdffcfcd23"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -2933,9 +2918,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "11.1.2"
+version = "11.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0ed01fe30ba5f5690115cbe531962bbbfc12603c695ceaddc28d457a646a05"
+checksum = "e2a21dd773b654ec7e080025eecef4ac84c711150d1bd36acadf0546f471329a"
 dependencies = [
  "auto_impl",
  "either",
@@ -2949,9 +2934,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "27.0.2"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0834fc25c020061f0f801d8de8bb53c88a63631cca5884a6c65b90c85e241138"
+checksum = "f1de5c790122f8ded67992312af8acd41ccfcee629b25b819e10c5b1f69caf57"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -2982,9 +2967,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "21.0.1"
+version = "21.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "536f30e24c3c2bf0d3d7d20fa9cf99b93040ed0f021fd9301c78cddb0dacda13"
+checksum = "29e161db429d465c09ba9cbff0df49e31049fe6b549e28eb0b7bd642fcbd4412"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -2994,9 +2979,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "8.0.2"
+version = "8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6bd5e669b02007872a8ca2643a14e308fe1739ee4475d74122587c3388a06a"
+checksum = "7d8be953b7e374dbdea0773cf360debed8df394ea8d82a8b240a6b5da37592fc"
 dependencies = [
  "bitflags",
  "revm-bytecode",
@@ -3025,14 +3010,14 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f5c3e5da784cd8c69d32cdc84673f3204536ca56e1fa01be31a74b92c932ac"
+checksum = "35a640b26f007713818e9a9b65d34da1cf58538207b052916a83d80e43f3ffa4"
 dependencies = [
  "bytecheck",
  "bytes",
  "hashbrown 0.15.5",
- "indexmap 2.10.0",
+ "indexmap 2.12.1",
  "munge",
  "ptr_meta",
  "rancor",
@@ -3044,13 +3029,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4270433626cffc9c4c1d3707dd681f2a2718d3d7b09ad754bec137acecda8d22"
+checksum = "bd83f5f173ff41e00337d97f6572e416d022ef8a19f371817259ae960324c482"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3065,13 +3050,14 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecb38f82477f20c5c3d62ef52d7c4e536e38ea9b73fb570a20c5cae0e14bcf6"
+checksum = "a68df0380e5c9d20ce49534f292a36a7514ae21350726efe1865bdb1fa91d278"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
+ "ark-ff 0.5.0",
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
@@ -3085,7 +3071,7 @@ dependencies = [
  "rand 0.9.2",
  "rlp",
  "ruint-macro",
- "serde",
+ "serde_core",
  "valuable",
  "zeroize",
 ]
@@ -3123,20 +3109,20 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.26",
+ "semver 1.0.27",
 ]
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3147,9 +3133,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
 dependencies = [
  "fnv",
  "quick-error",
@@ -3177,9 +3163,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -3234,9 +3220,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "semver-parser"
@@ -3274,36 +3260,36 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde_with"
-version = "3.14.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
+checksum = "10574371d41b0d9b2cff89418eda27da52bcaff2cc8741db26382a77c29131f1"
 dependencies = [
  "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.10.0",
+ "indexmap 2.12.1",
  "schemars 0.9.0",
- "schemars 1.0.4",
- "serde",
- "serde_derive",
+ "schemars 1.1.0",
+ "serde_core",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -3311,14 +3297,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.14.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
+checksum = "08a72d8216842fdd57820dc78d840bef99248e35fb2554ff923319e60f2d686b"
 dependencies = [
- "darling 0.20.11",
+ "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3385,6 +3371,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "simple-sparse-state"
+version = "0.1.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "alloy-trie 0.9.1",
+ "reth-errors",
+ "reth-primitives-traits",
+ "reth-revm",
+ "reth-stateless",
+ "reth-trie-common",
+ "simple-trie",
+]
+
+[[package]]
+name = "simple-trie"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-trie 0.8.1",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3425,9 +3435,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -3459,7 +3469,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3481,9 +3491,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.105"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc3fcb250e53458e712715cf74285c1f889686520d79294a9ef3bd7aa1fc619"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3492,14 +3502,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a985ff4ffd7373e10e0fb048110fb11a162e5a4c47f92ddb8787a6f766b769"
+checksum = "ff790eb176cc81bb8936aed0f7b9f14fc4670069a2d371b3e3b0ecce908b2cb3"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3510,7 +3520,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3521,35 +3531,35 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.14"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.14"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3563,9 +3573,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
@@ -3578,15 +3588,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3603,9 +3613,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3613,9 +3623,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3628,18 +3638,31 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.12.1",
  "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+dependencies = [
  "winnow",
 ]
 
@@ -3650,23 +3673,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
-name = "tracing-core"
-version = "0.1.34"
+name = "tracing-attributes"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "ucd-trie"
@@ -3694,9 +3729,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-segmentation"
@@ -3712,9 +3747,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3729,9 +3764,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3765,45 +3800,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.105",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3811,31 +3833,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
- "wasm-bindgen-backend",
+ "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -3846,220 +3868,79 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.3",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wyz"
@@ -4072,11 +3953,10 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -4084,34 +3964,34 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4131,15 +4011,15 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]
@@ -4152,14 +4032,14 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4168,9 +4048,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4179,13 +4059,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4208,9 +4088,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
+version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-json-abi"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5513d5e6bd1cba6bdcf5373470f559f320c05c8c59493b6e98912fbe6733943f"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "alloy-network-primitives"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,13 +363,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-sol-type-parser"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "954d1b2533b9b2c7959652df3076954ecb1122a28cc740aa84e7b0a49f6ac0a9"
+dependencies = [
+ "serde",
+ "winnow",
+]
+
+[[package]]
 name = "alloy-sol-types"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70319350969a3af119da6fb3e9bddb1bce66c9ea933600cb297c8b1850ad2a3c"
 dependencies = [
+ "alloy-json-abi",
  "alloy-primitives",
  "alloy-sol-macro",
+ "serde",
 ]
 
 [[package]]
@@ -398,7 +422,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae109e33814b49fc0a62f2528993aa8a2dd346c26959b151f05441dc0b9da292"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -412,6 +436,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "ark-bls12-381"
@@ -1053,12 +1083,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1078,11 +1132,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.111",
 ]
@@ -1288,6 +1353,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethereum_serde_utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
+dependencies = [
+ "alloy-primitives",
+ "hex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "ethereum_ssz"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
+dependencies = [
+ "alloy-primitives",
+ "ethereum_serde_utils",
+ "itertools 0.13.0",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "typenum",
+]
+
+[[package]]
+name = "ethereum_ssz_derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1443,6 +1548,24 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "guest-libs"
+version = "0.1.0"
+source = "git+https://github.com/eth-act/zkevm-benchmark-workload.git?rev=105443370827e17bf1aa6972cb2a35c6437a9dd8#105443370827e17bf1aa6972cb2a35c6437a9dd8"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits",
+ "reth-stateless",
+ "serde",
+ "serde_with",
+ "thiserror",
 ]
 
 [[package]]
@@ -1975,6 +2098,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -2571,6 +2695,7 @@ dependencies = [
  "alloy-serde",
  "reth-codecs",
  "reth-primitives-traits",
+ "reth-zstd-compressors",
  "serde",
  "serde_with",
 ]
@@ -2593,6 +2718,26 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie-common",
+ "revm",
+]
+
+[[package]]
+name = "reth-evm-ethereum"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "reth-chainspec",
+ "reth-ethereum-forks",
+ "reth-ethereum-primitives",
+ "reth-evm",
+ "reth-execution-types",
+ "reth-primitives-traits",
+ "reth-storage-errors",
  "revm",
 ]
 
@@ -2707,6 +2852,7 @@ dependencies = [
  "alloy-rpc-types-debug",
  "alloy-trie 0.9.1",
  "itertools 0.14.0",
+ "k256",
  "reth-chainspec",
  "reth-consensus",
  "reth-errors",
@@ -3301,7 +3447,7 @@ version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08a72d8216842fdd57820dc78d840bef99248e35fb2554ff923319e60f2d686b"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -3377,12 +3523,17 @@ dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-trie 0.9.1",
+ "anyhow",
+ "guest-libs",
+ "reth-chainspec",
  "reth-errors",
+ "reth-evm-ethereum",
  "reth-primitives-traits",
  "reth-revm",
  "reth-stateless",
  "reth-trie-common",
  "simple-trie",
+ "sparsestate",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08e9e656d58027542447c1ca5aa4ca96293f09e6920c4651953b7451a7c35e4e"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "auto_impl",
+ "derive_more",
+ "revm 30.2.0",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-evm"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01be36ba6f5e6e62563b369e03ca529eac46aea50677f84655084b4750816574"
@@ -150,7 +167,7 @@ dependencies = [
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "revm",
+ "revm 33.1.0",
  "thiserror",
 ]
 
@@ -180,6 +197,18 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "dyn-clone",
+]
+
+[[package]]
+name = "alloy-json-abi"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5513d5e6bd1cba6bdcf5373470f559f320c05c8c59493b6e98912fbe6733943f"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -351,13 +380,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-sol-type-parser"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b91b13181d3bcd23680fd29d7bc861d1f33fbe90fdd0af67162434aeba902d"
+dependencies = [
+ "serde",
+ "winnow",
+]
+
+[[package]]
 name = "alloy-sol-types"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70319350969a3af119da6fb3e9bddb1bce66c9ea933600cb297c8b1850ad2a3c"
 dependencies = [
+ "alloy-json-abi",
  "alloy-primitives",
  "alloy-sol-macro",
+ "serde",
 ]
 
 [[package]]
@@ -398,7 +439,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae109e33814b49fc0a62f2528993aa8a2dd346c26959b151f05441dc0b9da292"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -412,6 +453,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "ark-bls12-381"
@@ -1053,12 +1100,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1078,11 +1149,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.111",
 ]
@@ -1289,6 +1371,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethereum_serde_utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
+dependencies = [
+ "alloy-primitives",
+ "hex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "ethereum_ssz"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
+dependencies = [
+ "alloy-primitives",
+ "ethereum_serde_utils",
+ "itertools 0.13.0",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "typenum",
+]
+
+[[package]]
+name = "ethereum_ssz_derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,6 +1566,24 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "guest-libs"
+version = "0.1.0"
+source = "git+https://github.com/eth-act/zkevm-benchmark-workload.git?rev=105443370827e17bf1aa6972cb2a35c6437a9dd8#105443370827e17bf1aa6972cb2a35c6437a9dd8"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "ethereum_ssz",
+ "ethereum_ssz_derive",
+ "reth-ethereum-primitives 1.8.2",
+ "reth-primitives-traits 1.8.2",
+ "reth-stateless 1.8.2",
+ "serde",
+ "serde_with",
+ "thiserror",
 ]
 
 [[package]]
@@ -1976,6 +2116,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -2014,6 +2155,23 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 dependencies = [
  "critical-section",
  "portable-atomic",
+]
+
+[[package]]
+name = "op-alloy-consensus"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a501241474c3118833d6195312ae7eb7cc90bbb0d5f524cbb0b06619e49ff67"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "derive_more",
+ "serde",
+ "serde_with",
+ "thiserror",
 ]
 
 [[package]]
@@ -2439,22 +2597,60 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm 0.22.6",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-trie 0.9.1",
+ "auto_impl",
+ "derive_more",
+ "reth-ethereum-forks 1.8.2",
+ "reth-network-peers 1.8.2",
+ "reth-primitives-traits 1.8.2",
+ "serde_json",
+]
+
+[[package]]
+name = "reth-chainspec"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.24.2",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie 0.9.1",
  "auto_impl",
  "derive_more",
- "reth-ethereum-forks",
- "reth-network-peers",
- "reth-primitives-traits",
+ "reth-ethereum-forks 1.9.3",
+ "reth-network-peers 1.9.3",
+ "reth-primitives-traits 1.9.3",
  "serde_json",
+]
+
+[[package]]
+name = "reth-codecs"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-trie 0.9.1",
+ "bytes",
+ "modular-bitfield",
+ "op-alloy-consensus 0.20.0",
+ "reth-codecs-derive 1.8.2",
+ "reth-zstd-compressors 1.8.2",
+ "serde",
 ]
 
 [[package]]
@@ -2469,10 +2665,20 @@ dependencies = [
  "alloy-trie 0.9.1",
  "bytes",
  "modular-bitfield",
- "op-alloy-consensus",
- "reth-codecs-derive",
- "reth-zstd-compressors",
+ "op-alloy-consensus 0.22.4",
+ "reth-codecs-derive 1.9.3",
+ "reth-zstd-compressors 1.9.3",
  "serde",
+]
+
+[[package]]
+name = "reth-codecs-derive"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2487,15 +2693,40 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "auto_impl",
+ "reth-execution-types 1.8.2",
+ "reth-primitives-traits 1.8.2",
+ "thiserror",
+]
+
+[[package]]
+name = "reth-consensus"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "auto_impl",
- "reth-execution-types",
- "reth-primitives-traits",
+ "reth-execution-types 1.9.3",
+ "reth-primitives-traits 1.9.3",
  "thiserror",
+]
+
+[[package]]
+name = "reth-consensus-common"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "reth-chainspec 1.8.2",
+ "reth-consensus 1.8.2",
+ "reth-primitives-traits 1.8.2",
 ]
 
 [[package]]
@@ -2505,9 +2736,19 @@ source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "reth-chainspec",
- "reth-consensus",
- "reth-primitives-traits",
+ "reth-chainspec 1.9.3",
+ "reth-consensus 1.9.3",
+ "reth-primitives-traits 1.9.3",
+]
+
+[[package]]
+name = "reth-db-models"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "reth-primitives-traits 1.8.2",
 ]
 
 [[package]]
@@ -2517,7 +2758,18 @@ source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.9.3",
+]
+
+[[package]]
+name = "reth-errors"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "reth-consensus 1.8.2",
+ "reth-execution-errors 1.8.2",
+ "reth-storage-errors 1.8.2",
+ "thiserror",
 ]
 
 [[package]]
@@ -2525,10 +2777,26 @@ name = "reth-errors"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
- "reth-consensus",
- "reth-execution-errors",
- "reth-storage-errors",
+ "reth-consensus 1.9.3",
+ "reth-execution-errors 1.9.3",
+ "reth-storage-errors 1.9.3",
  "thiserror",
+]
+
+[[package]]
+name = "reth-ethereum-consensus"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "reth-chainspec 1.8.2",
+ "reth-consensus 1.8.2",
+ "reth-consensus-common 1.8.2",
+ "reth-execution-types 1.8.2",
+ "reth-primitives-traits 1.8.2",
+ "tracing",
 ]
 
 [[package]]
@@ -2539,12 +2807,24 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "reth-chainspec",
- "reth-consensus",
- "reth-consensus-common",
- "reth-execution-types",
- "reth-primitives-traits",
+ "reth-chainspec 1.9.3",
+ "reth-consensus 1.9.3",
+ "reth-consensus-common 1.9.3",
+ "reth-execution-types 1.9.3",
+ "reth-primitives-traits 1.9.3",
  "tracing",
+]
+
+[[package]]
+name = "reth-ethereum-forks"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "auto_impl",
+ "once_cell",
 ]
 
 [[package]]
@@ -2561,6 +2841,24 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "reth-codecs 1.8.2",
+ "reth-primitives-traits 1.8.2",
+ "reth-zstd-compressors 1.8.2",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
+name = "reth-ethereum-primitives"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
@@ -2570,10 +2868,31 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-serde",
- "reth-codecs",
- "reth-primitives-traits",
+ "reth-codecs 1.9.3",
+ "reth-primitives-traits 1.9.3",
  "serde",
  "serde_with",
+]
+
+[[package]]
+name = "reth-evm"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm 0.22.6",
+ "alloy-primitives",
+ "auto_impl",
+ "derive_more",
+ "futures-util",
+ "reth-execution-errors 1.8.2",
+ "reth-execution-types 1.8.2",
+ "reth-primitives-traits 1.8.2",
+ "reth-storage-api 1.8.2",
+ "reth-storage-errors 1.8.2",
+ "reth-trie-common 1.8.2",
+ "revm 30.2.0",
 ]
 
 [[package]]
@@ -2583,18 +2902,51 @@ source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.24.2",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
  "futures-util",
- "reth-execution-errors",
- "reth-execution-types",
- "reth-primitives-traits",
- "reth-storage-api",
- "reth-storage-errors",
- "reth-trie-common",
- "revm",
+ "reth-execution-errors 1.9.3",
+ "reth-execution-types 1.9.3",
+ "reth-primitives-traits 1.9.3",
+ "reth-storage-api 1.9.3",
+ "reth-storage-errors 1.9.3",
+ "reth-trie-common 1.9.3",
+ "revm 33.1.0",
+]
+
+[[package]]
+name = "reth-evm-ethereum"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm 0.22.6",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "reth-chainspec 1.8.2",
+ "reth-ethereum-forks 1.8.2",
+ "reth-ethereum-primitives 1.8.2",
+ "reth-evm 1.8.2",
+ "reth-execution-types 1.8.2",
+ "reth-primitives-traits 1.8.2",
+ "reth-storage-errors 1.8.2",
+ "revm 30.2.0",
+]
+
+[[package]]
+name = "reth-execution-errors"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-evm 0.22.6",
+ "alloy-primitives",
+ "alloy-rlp",
+ "nybbles 0.4.6",
+ "reth-storage-errors 1.8.2",
+ "thiserror",
 ]
 
 [[package]]
@@ -2602,12 +2954,28 @@ name = "reth-execution-errors"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
- "alloy-evm",
+ "alloy-evm 0.24.2",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles 0.4.6",
- "reth-storage-errors",
+ "reth-storage-errors 1.9.3",
  "thiserror",
+]
+
+[[package]]
+name = "reth-execution-types"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-evm 0.22.6",
+ "alloy-primitives",
+ "derive_more",
+ "reth-ethereum-primitives 1.8.2",
+ "reth-primitives-traits 1.8.2",
+ "reth-trie-common 1.8.2",
+ "revm 30.2.0",
 ]
 
 [[package]]
@@ -2617,13 +2985,25 @@ source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.24.2",
  "alloy-primitives",
  "derive_more",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-trie-common",
- "revm",
+ "reth-ethereum-primitives 1.9.3",
+ "reth-primitives-traits 1.9.3",
+ "reth-trie-common 1.9.3",
+ "revm 33.1.0",
+]
+
+[[package]]
+name = "reth-network-peers"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "serde_with",
+ "thiserror",
+ "url",
 ]
 
 [[package]]
@@ -2636,6 +3016,33 @@ dependencies = [
  "serde_with",
  "thiserror",
  "url",
+]
+
+[[package]]
+name = "reth-primitives-traits"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "alloy-trie 0.9.1",
+ "auto_impl",
+ "bytes",
+ "derive_more",
+ "once_cell",
+ "op-alloy-consensus 0.20.0",
+ "reth-codecs 1.8.2",
+ "revm-bytecode",
+ "revm-primitives",
+ "revm-state",
+ "secp256k1",
+ "serde",
+ "serde_with",
+ "thiserror",
 ]
 
 [[package]]
@@ -2654,14 +3061,24 @@ dependencies = [
  "bytes",
  "derive_more",
  "once_cell",
- "op-alloy-consensus",
- "reth-codecs",
+ "op-alloy-consensus 0.22.4",
+ "reth-codecs 1.9.3",
  "revm-bytecode",
  "revm-primitives",
  "revm-state",
  "secp256k1",
  "serde",
  "serde_with",
+ "thiserror",
+]
+
+[[package]]
+name = "reth-prune-types"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-primitives",
+ "derive_more",
  "thiserror",
 ]
 
@@ -2678,14 +3095,35 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-primitives",
+ "reth-primitives-traits 1.8.2",
+ "reth-storage-api 1.8.2",
+ "reth-storage-errors 1.8.2",
+ "revm 30.2.0",
+]
+
+[[package]]
+name = "reth-revm"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
- "reth-primitives-traits",
- "reth-storage-api",
- "reth-storage-errors",
- "revm",
+ "reth-primitives-traits 1.9.3",
+ "reth-storage-api 1.9.3",
+ "reth-storage-errors 1.9.3",
+ "revm 33.1.0",
+]
+
+[[package]]
+name = "reth-stages-types"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-primitives",
+ "reth-trie-common 1.8.2",
 ]
 
 [[package]]
@@ -2694,7 +3132,36 @@ version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
  "alloy-primitives",
- "reth-trie-common",
+ "reth-trie-common 1.9.3",
+]
+
+[[package]]
+name = "reth-stateless"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-consensus",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-debug",
+ "alloy-trie 0.9.1",
+ "itertools 0.14.0",
+ "k256",
+ "reth-chainspec 1.8.2",
+ "reth-consensus 1.8.2",
+ "reth-errors 1.8.2",
+ "reth-ethereum-consensus 1.8.2",
+ "reth-ethereum-primitives 1.8.2",
+ "reth-evm 1.8.2",
+ "reth-primitives-traits 1.8.2",
+ "reth-revm 1.8.2",
+ "reth-trie-common 1.8.2",
+ "reth-trie-sparse 1.8.2",
+ "serde",
+ "serde_with",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -2709,19 +3176,30 @@ dependencies = [
  "alloy-rpc-types-debug",
  "alloy-trie 0.9.1",
  "itertools 0.14.0",
- "reth-chainspec",
- "reth-consensus",
- "reth-errors",
- "reth-ethereum-consensus",
- "reth-ethereum-primitives",
- "reth-evm",
- "reth-primitives-traits",
- "reth-revm",
- "reth-trie-common",
- "reth-trie-sparse",
+ "reth-chainspec 1.9.3",
+ "reth-consensus 1.9.3",
+ "reth-errors 1.9.3",
+ "reth-ethereum-consensus 1.9.3",
+ "reth-ethereum-primitives 1.9.3",
+ "reth-evm 1.9.3",
+ "reth-primitives-traits 1.9.3",
+ "reth-revm 1.9.3",
+ "reth-trie-common 1.9.3",
+ "reth-trie-sparse 1.9.3",
  "serde",
  "serde_with",
  "thiserror",
+]
+
+[[package]]
+name = "reth-static-file-types"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-primitives",
+ "derive_more",
+ "serde",
+ "strum",
 ]
 
 [[package]]
@@ -2737,6 +3215,28 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "auto_impl",
+ "reth-chainspec 1.8.2",
+ "reth-db-models 1.8.2",
+ "reth-ethereum-primitives 1.8.2",
+ "reth-execution-types 1.8.2",
+ "reth-primitives-traits 1.8.2",
+ "reth-prune-types 1.8.2",
+ "reth-stages-types 1.8.2",
+ "reth-storage-errors 1.8.2",
+ "reth-trie-common 1.8.2",
+ "revm-database",
+]
+
+[[package]]
+name = "reth-storage-api"
 version = "1.9.3"
 source = "git+https://github.com/paradigmxyz/reth?rev=cfde951976bfa9100a6d9f806e06fb539ae25241#cfde951976bfa9100a6d9f806e06fb539ae25241"
 dependencies = [
@@ -2745,16 +3245,32 @@ dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "auto_impl",
- "reth-chainspec",
- "reth-db-models",
- "reth-ethereum-primitives",
- "reth-execution-types",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-stages-types",
- "reth-storage-errors",
- "reth-trie-common",
+ "reth-chainspec 1.9.3",
+ "reth-db-models 1.9.3",
+ "reth-ethereum-primitives 1.9.3",
+ "reth-execution-types 1.9.3",
+ "reth-primitives-traits 1.9.3",
+ "reth-prune-types 1.9.3",
+ "reth-stages-types 1.9.3",
+ "reth-storage-errors 1.9.3",
+ "reth-trie-common 1.9.3",
  "revm-database",
+]
+
+[[package]]
+name = "reth-storage-errors"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more",
+ "reth-primitives-traits 1.8.2",
+ "reth-prune-types 1.8.2",
+ "reth-static-file-types 1.8.2",
+ "revm-database-interface",
+ "thiserror",
 ]
 
 [[package]]
@@ -2766,11 +3282,27 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-static-file-types",
+ "reth-primitives-traits 1.9.3",
+ "reth-prune-types 1.9.3",
+ "reth-static-file-types 1.9.3",
  "revm-database-interface",
  "thiserror",
+]
+
+[[package]]
+name = "reth-trie-common"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-trie 0.9.1",
+ "derive_more",
+ "itertools 0.14.0",
+ "nybbles 0.4.6",
+ "reth-primitives-traits 1.8.2",
+ "revm-database",
 ]
 
 [[package]]
@@ -2785,8 +3317,24 @@ dependencies = [
  "derive_more",
  "itertools 0.14.0",
  "nybbles 0.4.6",
- "reth-primitives-traits",
+ "reth-primitives-traits 1.9.3",
  "revm-database",
+]
+
+[[package]]
+name = "reth-trie-sparse"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-trie 0.9.1",
+ "auto_impl",
+ "reth-execution-errors 1.8.2",
+ "reth-primitives-traits 1.8.2",
+ "reth-trie-common 1.8.2",
+ "smallvec",
+ "tracing",
 ]
 
 [[package]]
@@ -2798,11 +3346,19 @@ dependencies = [
  "alloy-rlp",
  "alloy-trie 0.9.1",
  "auto_impl",
- "reth-execution-errors",
- "reth-primitives-traits",
- "reth-trie-common",
+ "reth-execution-errors 1.9.3",
+ "reth-primitives-traits 1.9.3",
+ "reth-trie-common 1.9.3",
  "smallvec",
  "tracing",
+]
+
+[[package]]
+name = "reth-zstd-compressors"
+version = "1.8.2"
+source = "git+https://github.com/kevaundray/reth?rev=5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb#5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb"
+dependencies = [
+ "zstd",
 ]
 
 [[package]]
@@ -2815,19 +3371,38 @@ dependencies = [
 
 [[package]]
 name = "revm"
+version = "30.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76df793c6ef3bef8f88f05b3873ebebce1494385a3ce8f58ad2e2e111aa0de11"
+dependencies = [
+ "revm-bytecode",
+ "revm-context 10.1.2",
+ "revm-context-interface 11.1.2",
+ "revm-database",
+ "revm-database-interface",
+ "revm-handler 11.2.0",
+ "revm-inspector 11.2.0",
+ "revm-interpreter 28.0.0",
+ "revm-precompile 28.1.1",
+ "revm-primitives",
+ "revm-state",
+]
+
+[[package]]
+name = "revm"
 version = "33.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c85ed0028f043f87b3c88d4a4cb6f0a76440085523b6a8afe5ff003cf418054"
 dependencies = [
  "revm-bytecode",
- "revm-context",
- "revm-context-interface",
+ "revm-context 12.1.0",
+ "revm-context-interface 13.1.0",
  "revm-database",
  "revm-database-interface",
- "revm-handler",
- "revm-inspector",
- "revm-interpreter",
- "revm-precompile",
+ "revm-handler 14.1.0",
+ "revm-inspector 14.1.0",
+ "revm-interpreter 31.1.0",
+ "revm-precompile 31.0.0",
  "revm-primitives",
  "revm-state",
 ]
@@ -2846,6 +3421,22 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
+version = "10.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7adcce0c14cf59b7128de34185a0fbf8f63309539b9263b35ead870d73584114"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "derive-where",
+ "revm-bytecode",
+ "revm-context-interface 11.1.2",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+]
+
+[[package]]
+name = "revm-context"
 version = "12.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f038f0c9c723393ac897a5df9140b21cfa98f5753a2cb7d0f28fa430c4118abf"
@@ -2854,7 +3445,22 @@ dependencies = [
  "cfg-if",
  "derive-where",
  "revm-bytecode",
- "revm-context-interface",
+ "revm-context-interface 13.1.0",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "11.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d620a9725e443c171fb195a074331fa4a745fa5cbb0018b4bbf42619e64b563"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "either",
  "revm-database-interface",
  "revm-primitives",
  "revm-state",
@@ -2901,6 +3507,24 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
+version = "11.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d8049b2fbff6636150f4740c95369aa174e41b0383034e0e256cfdffcfcd23"
+dependencies = [
+ "auto_impl",
+ "derive-where",
+ "revm-bytecode",
+ "revm-context 10.1.2",
+ "revm-context-interface 11.1.2",
+ "revm-database-interface",
+ "revm-interpreter 28.0.0",
+ "revm-precompile 28.1.1",
+ "revm-primitives",
+ "revm-state",
+]
+
+[[package]]
+name = "revm-handler"
 version = "14.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d44f8f6dbeec3fecf9fe55f78ef0a758bdd92ea46cd4f1ca6e2a946b32c367f3"
@@ -2908,11 +3532,27 @@ dependencies = [
  "auto_impl",
  "derive-where",
  "revm-bytecode",
- "revm-context",
- "revm-context-interface",
+ "revm-context 12.1.0",
+ "revm-context-interface 13.1.0",
  "revm-database-interface",
- "revm-interpreter",
- "revm-precompile",
+ "revm-interpreter 31.1.0",
+ "revm-precompile 31.0.0",
+ "revm-primitives",
+ "revm-state",
+]
+
+[[package]]
+name = "revm-inspector"
+version = "11.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2a21dd773b654ec7e080025eecef4ac84c711150d1bd36acadf0546f471329a"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-context 10.1.2",
+ "revm-database-interface",
+ "revm-handler 11.2.0",
+ "revm-interpreter 28.0.0",
  "revm-primitives",
  "revm-state",
 ]
@@ -2925,10 +3565,22 @@ checksum = "5617e49216ce1ca6c8826bcead0386bc84f49359ef67cde6d189961735659f93"
 dependencies = [
  "auto_impl",
  "either",
- "revm-context",
+ "revm-context 12.1.0",
  "revm-database-interface",
- "revm-handler",
- "revm-interpreter",
+ "revm-handler 14.1.0",
+ "revm-interpreter 31.1.0",
+ "revm-primitives",
+ "revm-state",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "28.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1de5c790122f8ded67992312af8acd41ccfcee629b25b819e10c5b1f69caf57"
+dependencies = [
+ "revm-bytecode",
+ "revm-context-interface 11.1.2",
  "revm-primitives",
  "revm-state",
 ]
@@ -2940,9 +3592,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26ec36405f7477b9dccdc6caa3be19adf5662a7a0dffa6270cdb13a090c077e5"
 dependencies = [
  "revm-bytecode",
- "revm-context-interface",
+ "revm-context-interface 13.1.0",
  "revm-primitives",
  "revm-state",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "28.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57aadd7a2087705f653b5aaacc8ad4f8e851f5d330661e3f4c43b5475bbceae"
+dependencies = [
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "arrayref",
+ "aurora-engine-modexp",
+ "cfg-if",
+ "k256",
+ "p256",
+ "revm-primitives",
+ "ripemd",
+ "sha2",
 ]
 
 [[package]]
@@ -3302,7 +3975,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -3372,6 +4045,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "simple-sparse-state"
+version = "0.1.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "alloy-trie 0.9.1",
+ "anyhow",
+ "guest-libs",
+ "reth-chainspec 1.8.2",
+ "reth-errors 1.8.2",
+ "reth-evm-ethereum",
+ "reth-primitives-traits 1.8.2",
+ "reth-revm 1.8.2",
+ "reth-stateless 1.8.2",
+ "reth-trie-common 1.8.2",
+ "simple-trie",
+ "sparsestate",
+]
+
+[[package]]
+name = "simple-trie"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-trie 0.8.1",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3394,10 +4096,10 @@ dependencies = [
  "alloy-rlp",
  "alloy-trie 0.9.1",
  "mpt",
- "reth-errors",
- "reth-revm",
- "reth-stateless",
- "reth-trie-common",
+ "reth-errors 1.9.3",
+ "reth-revm 1.9.3",
+ "reth-stateless 1.9.3",
+ "reth-trie-common 1.9.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/mpt", "crates/sparsestate"]
+members = ["crates/mpt", "crates/simple-sparse-state", "crates/simple-trie", "crates/sparsestate"]
 resolver = "2"
 
 [workspace.package]
@@ -92,3 +92,11 @@ zero_sized_map_values = "warn"
 
 
 [workspace.dependencies]
+alloy-primitives = { version = "1.4.1", default-features = false }
+alloy-trie = { version = "0.9.1", default-features = false }
+alloy-rlp = { version = "0.3.10", default-features = false }
+reth-errors = { git = "https://github.com/kevaundray/reth", rev = "5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb", default-features = false }
+reth-stateless = { git = "https://github.com/kevaundray/reth", rev = "5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb", default-features = false }
+reth-trie-common = { git = "https://github.com/kevaundray/reth", rev = "5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb", default-features = false }
+reth-revm = { git = "https://github.com/kevaundray/reth", rev = "5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb", default-features = false }
+reth-primitives-traits = { git = "https://github.com/kevaundray/reth", rev = "5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,10 @@ alloy-primitives = { version = "1.4.1", default-features = false }
 alloy-trie = { version = "0.9.1", default-features = false }
 alloy-rlp = { version = "0.3.10", default-features = false }
 reth-errors = { git = "https://github.com/kevaundray/reth", rev = "5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/kevaundray/reth", rev = "5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb", default-features = false }
 reth-stateless = { git = "https://github.com/kevaundray/reth", rev = "5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb", default-features = false }
 reth-trie-common = { git = "https://github.com/kevaundray/reth", rev = "5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb", default-features = false }
 reth-revm = { git = "https://github.com/kevaundray/reth", rev = "5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb", default-features = false }
 reth-primitives-traits = { git = "https://github.com/kevaundray/reth", rev = "5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb", default-features = false }
+reth-chainspec = { git = "https://github.com/kevaundray/reth", rev = "5b4c3a6d75de93c3ad5d2c8c2740c63cb7e74afb", default-features = false }
+guest-libs = { git = "https://github.com/eth-act/zkevm-benchmark-workload.git", rev = "105443370827e17bf1aa6972cb2a35c6437a9dd8" }

--- a/crates/simple-sparse-state/Cargo.toml
+++ b/crates/simple-sparse-state/Cargo.toml
@@ -1,21 +1,25 @@
 [package]
-name = "sparsestate"
+name = "simple-sparse-state"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+
 alloy-primitives.workspace = true
 alloy-trie.workspace = true
-alloy-rlp.workspace = true
-
 reth-errors.workspace = true
 reth-stateless.workspace = true
-reth-trie-common.workspace = true
 reth-revm.workspace = true
+reth-trie-common.workspace = true
+simple-trie = { path = "../simple-trie" }
 
-mpt = { path = "../mpt" }
+[dev-dependencies]
+alloy-consensus = { version = "1.0.42", default-features = false }
+reth-primitives-traits.workspace = true
 
 [lints]
 workspace = true
+
+

--- a/crates/simple-sparse-state/Cargo.toml
+++ b/crates/simple-sparse-state/Cargo.toml
@@ -17,7 +17,12 @@ simple-trie = { path = "../simple-trie" }
 
 [dev-dependencies]
 alloy-consensus = { version = "1.0.42", default-features = false }
+guest-libs.workspace = true
+reth-evm-ethereum.workspace = true
+reth-chainspec.workspace = true
 reth-primitives-traits.workspace = true
+anyhow = "1.0"
+sparsestate = { path = "../sparsestate" }
 
 [lints]
 workspace = true

--- a/crates/simple-sparse-state/src/lib.rs
+++ b/crates/simple-sparse-state/src/lib.rs
@@ -1,0 +1,354 @@
+//! A sparse state implementation based on simple sparse trie.
+use alloy_primitives::private::alloy_rlp;
+use alloy_primitives::private::alloy_rlp::Decodable;
+use alloy_primitives::{Address, Bytes, KECCAK256_EMPTY, U256, keccak256, map::hash_map::Entry};
+use alloy_trie::{EMPTY_ROOT_HASH, TrieAccount};
+use reth_errors::ProviderError;
+use reth_revm::bytecode::Bytecode;
+use reth_stateless::validation::StatelessValidationError;
+use reth_stateless::{ExecutionWitness, StatelessTrie};
+use reth_trie_common::HashedPostState;
+use simple_trie::Nibbles;
+use simple_trie::Trie;
+use simple_trie::{B256, B256Map};
+use std::cell::RefCell;
+
+/// Implementation of a simple sparse state based on simple_trie
+#[derive(Debug, Clone)]
+pub struct SimpleSparseState {
+    state: Trie,
+    storages: RefCell<B256Map<Box<Trie>>>,
+    rlp_by_digest: B256Map<Bytes>,
+}
+
+impl SimpleSparseState {
+    /// Removes an account from the state.
+    fn remove_account(&mut self, hashed_address: &B256) {
+        self.state.remove(Nibbles::unpack(hashed_address));
+        self.storages.get_mut().remove(hashed_address);
+    }
+
+    /// Clears the storage of an account.
+    fn clear_storage(&mut self, hashed_address: B256) -> &mut Box<Trie> {
+        match self.storages.get_mut().entry(hashed_address) {
+            Entry::Occupied(mut entry) => {
+                entry.insert(Box::new(Trie::new()));
+                entry
+            }
+            Entry::Vacant(entry) => entry.insert_entry(Box::new(Trie::new())),
+        }
+        .into_mut()
+    }
+
+    /// Returns a mutable version of the storage trie of the given account.
+    fn storage_trie_mut(&mut self, hashed_address: B256) -> alloy_rlp::Result<&mut Box<Trie>> {
+        let trie = match self.storages.get_mut().entry(hashed_address) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => {
+                // build the storage trie matching the storage root of the account
+                let storage_root = self.state.get(Nibbles::unpack(hashed_address)).map_or(
+                    EMPTY_ROOT_HASH,
+                    |value| {
+                        alloy_rlp::decode_exact::<TrieAccount>(value)
+                            .unwrap()
+                            .storage_root
+                    },
+                );
+                entry.insert(Box::new(Trie::reveal_from_rlp(
+                    storage_root,
+                    &self.rlp_by_digest,
+                )))
+            }
+        };
+
+        Ok(trie)
+    }
+}
+
+impl StatelessTrie for SimpleSparseState {
+    fn new(
+        witness: &ExecutionWitness,
+        pre_state_root: B256,
+    ) -> Result<(Self, B256Map<Bytecode>), StatelessValidationError>
+    where
+        Self: Sized,
+    {
+        // fist, hash all the RLP nodes once
+        let rlp_by_digest: B256Map<_> = witness
+            .state
+            .iter()
+            .map(|rlp| (keccak256(rlp), rlp.clone()))
+            .collect();
+
+        // construct the state trie from the witness data and the given state root
+        let mut state = Trie::reveal_from_rlp(pre_state_root, &rlp_by_digest);
+
+        // hash all the supplied bytecode
+        let bytecode = witness
+            .codes
+            .iter()
+            .map(|code| (keccak256(code), Bytecode::new_raw(code.clone())))
+            .collect();
+
+        debug_assert_eq!(state.hash(), pre_state_root);
+        Ok((
+            SimpleSparseState {
+                state,
+                storages: RefCell::new(B256Map::default()),
+                rlp_by_digest,
+            },
+            bytecode,
+        ))
+    }
+
+    fn account(&self, address: Address) -> Result<Option<TrieAccount>, ProviderError> {
+        let hashed_address = keccak256(address);
+        let key = Nibbles::unpack(hashed_address);
+
+        match self.state.get(key) {
+            Some(value) => {
+                match alloy_rlp::decode_exact(value.as_ref()) as Result<TrieAccount, _> {
+                    Ok(account) => {
+                        match self.storages.borrow_mut().entry(hashed_address) {
+                            Entry::Vacant(entry) => {
+                                if account.storage_root != EMPTY_ROOT_HASH {
+                                    let t = Box::new(Trie::reveal_from_rlp(
+                                        account.storage_root,
+                                        &self.rlp_by_digest,
+                                    ));
+                                    entry.insert(t);
+                                } else {
+                                    entry.insert(Box::new(Trie::new()));
+                                }
+                            }
+                            Entry::Occupied(_) => {}
+                        }
+                        Ok(Some(account))
+                    }
+                    Err(_) => Ok(None),
+                }
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn storage(&self, address: Address, slot: U256) -> Result<U256, ProviderError> {
+        match self.storages.borrow_mut().get(&keccak256(address)) {
+            Some(storage_trie) => {
+                let path = Nibbles::unpack(keccak256(B256::from(slot)));
+                match storage_trie.get(path) {
+                    Some(value) => Ok(U256::decode(&mut &value[..]).unwrap()),
+                    None => Ok(U256::ZERO),
+                }
+            }
+            None => Ok(U256::ZERO),
+        }
+    }
+
+    fn calculate_state_root(
+        &mut self,
+        state: HashedPostState,
+    ) -> Result<B256, StatelessValidationError> {
+        let mut removed_accounts = Vec::new();
+
+        for (hashed_address, account) in state.accounts {
+            // nonexisting accounts must be removed from the state
+            let Some(account) = account else {
+                removed_accounts.push(hashed_address);
+                continue;
+            };
+
+            // apply storage changes before computing the storage root
+            let storage_root = match state.storages.get(&hashed_address) {
+                None => self.storage_trie_mut(hashed_address).unwrap().hash(),
+                Some(storage) => {
+                    let storage_trie = if storage.wiped {
+                        self.clear_storage(hashed_address)
+                    } else {
+                        self.storage_trie_mut(hashed_address).unwrap()
+                    };
+
+                    // apply all state modifications
+                    for (hashed_key, value) in &storage.storage {
+                        if !value.is_zero() {
+                            storage_trie.insert(
+                                Nibbles::unpack(hashed_key),
+                                alloy_rlp::encode(value).into(),
+                            );
+                        }
+                    }
+                    // removals must happen last, otherwise unresolved orphans might still exist
+                    for (hashed_key, value) in &storage.storage {
+                        if value.is_zero() {
+                            storage_trie.remove(Nibbles::unpack(hashed_key));
+                        }
+                    }
+
+                    storage_trie.hash()
+                }
+            };
+
+            // update/insert the account after all changes have been processed
+            let account = TrieAccount {
+                nonce: account.nonce,
+                balance: account.balance,
+                storage_root,
+                code_hash: account.bytecode_hash.unwrap_or(KECCAK256_EMPTY),
+            };
+            self.state.insert(
+                Nibbles::unpack(hashed_address),
+                alloy_rlp::encode(account).into(),
+            );
+        }
+
+        removed_accounts
+            .iter()
+            .for_each(|hashed_address| self.remove_account(hashed_address));
+
+        Ok(self.state.hash())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::Header;
+    use alloy_primitives::hex;
+    use reth_primitives_traits::account::Account;
+
+    #[test]
+    fn test_sparse_state() {
+        let state: Vec<Bytes> = {
+            [
+                Bytes::from(hex!("0xf869a0206aea581b220579a2b99819299dd32c7c28a420018ecb0bde93af007ad89a31b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a078c6cb5202685228bbcbfb992b1c4e116c7ec5ef11e25b8e92716cfc628ddd60")),
+                Bytes::from(hex!("0xf869a037d65eaa92c6bc4c13a5ec45527f0c18ea8932588728769ec7aecfe6d9f32e42b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0f57acd40259872606d76197ef052f3d35588dadf919ee1f0e3cb9b62d3f4b02c")),
+                Bytes::from(hex!("0xf8b1a0c4b823e1deb537a6b4c41ecc9123e37753d61894f9dee7022b29c83088f69cfba00d1c2f6add00c6786d64a77d4136f71ef02f4a69307c77b663f32875ae8c7d9780a066a64e47bae97c0fccdc260c76b1c987c89560cb40e86ea17a1d5fd49e35bebe8080a039e4714d1eb6e1d5b21ca2bffd56333a7cd697596ff64317d1ae21ffd048e6ca808080808080a008be39f7c15cc06a7d863615397887281eadcbdb7907665d0683ca3c6383e6b0808080")),
+                Bytes::from(hex!("0xf869a03f86c581c7d7b44eecbb92fd9e5867945ec1acdc0ea5bbabda21d17dddf06473b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a00345a365d2f4c5975b9f1599abe0a2ee76b7a3a731bc68781bd04c84e4858f50")),
+                Bytes::from(hex!("0xf869a03d7dcb6a0ce5227c5379fc5b0e004561d7833b063355f69bfea3178f08fbaab4b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a09fb907ad9cb2872884a1e6839fcf89d229ef9b43df0511f58dbb26a1217ecb0d")),
+                Bytes::from(hex!("0xf851808080a0de090f75dbe520ac527f21140ede3807a7dc416a0bae24c33dde9fe04300a08c808080808080808080a0f215e6bc9ca85972bc2488943dca80313a019f5eb569cc6ee3dc8c2af68734af808080")),
+                Bytes::from(hex!("0x80")),
+                Bytes::from(hex!("0xf851808080808080808080808080a031357c4a138624e300159fc631211a29d8373db4bdf59b80dad6e816593d0bcb8080a0b5790ff14363bee5d40c4a9fd9d6a515fc44683cc4d46666b4d9c775dded101780")),
+                Bytes::from(hex!("0xf871a020601462093b5945d1676df093446790fd31b20e7b12a2e8e5e09d068109616bb84ef84c80880de0b6b3a7640000a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")),
+                Bytes::from(hex!("0xf869a0209d57be05dd69371c4dd2e871bce6e9f4124236825bb612ee18a45e5675be51b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a06e49e66782037c0555897870e29fa5e552daf4719552131a0abce779daec0a5d"))
+            ].to_vec()
+        };
+
+        let codes: Vec<Bytes> = {
+            [
+            Bytes::from(hex!("0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500")),
+            Bytes::from(hex!("0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500")),
+            Bytes::from(hex!("0x3373fffffffffffffffffffffffffffffffffffffffe1460cb5760115f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff146101f457600182026001905f5b5f82111560685781019083028483029004916001019190604d565b909390049250505036603814608857366101f457346101f4575f5260205ff35b34106101f457600154600101600155600354806003026004013381556001015f35815560010160203590553360601b5f5260385f601437604c5fa0600101600355005b6003546002548082038060101160df575060105b5f5b8181146101835782810160030260040181604c02815460601b8152601401816001015481526020019060020154807fffffffffffffffffffffffffffffffff00000000000000000000000000000000168252906010019060401c908160381c81600701538160301c81600601538160281c81600501538160201c81600401538160181c81600301538160101c81600201538160081c81600101535360010160e1565b910180921461019557906002556101a0565b90505f6002555f6003555b5f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff14156101cd57505f5b6001546002828201116101e25750505f6101e8565b01600290035b5f555f600155604c025ff35b5f5ffd")),
+            Bytes::from(hex!("0x3373fffffffffffffffffffffffffffffffffffffffe1460d35760115f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1461019a57600182026001905f5b5f82111560685781019083028483029004916001019190604d565b9093900492505050366060146088573661019a573461019a575f5260205ff35b341061019a57600154600101600155600354806004026004013381556001015f358155600101602035815560010160403590553360601b5f5260605f60143760745fa0600101600355005b6003546002548082038060021160e7575060025b5f5b8181146101295782810160040260040181607402815460601b815260140181600101548152602001816002015481526020019060030154905260010160e9565b910180921461013b5790600255610146565b90505f6002555f6003555b5f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff141561017357505f5b6001546001828201116101885750505f61018e565b01600190035b5f555f6001556074025ff35b5f5ffd")),
+            Bytes::from(hex!("0x366000600037600060003660006000600b610177f26000553d6001553d600060003e3d600020600255")),
+            Bytes::from(hex!("0x"))
+        ].to_vec()
+        };
+
+        let keys: Vec<Bytes> = {
+            [
+                Bytes::from(hex!("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b")),
+                Bytes::from(hex!("0x0000f90827f1c53a10cb7a02335b175320002935")),
+                Bytes::from(hex!(
+                    "0x0000000000000000000000000000000000000000000000000000000000000000"
+                )),
+                Bytes::from(hex!("0x00000961ef480eb55e80d19ad83579a64c007002")),
+                Bytes::from(hex!(
+                    "0x0000000000000000000000000000000000000000000000000000000000000002"
+                )),
+                Bytes::from(hex!(
+                    "0x0000000000000000000000000000000000000000000000000000000000000000"
+                )),
+                Bytes::from(hex!(
+                    "0x0000000000000000000000000000000000000000000000000000000000000003"
+                )),
+                Bytes::from(hex!(
+                    "0x0000000000000000000000000000000000000000000000000000000000000001"
+                )),
+                Bytes::from(hex!("0x000f3df6d732807ef1319fb7b8bb8522d0beac02")),
+                Bytes::from(hex!(
+                    "0x00000000000000000000000000000000000000000000000000000000000003e8"
+                )),
+                Bytes::from(hex!(
+                    "0x00000000000000000000000000000000000000000000000000000000000023e7"
+                )),
+                Bytes::from(hex!("0x0000bbddc7ce488642fb579f8b00f3a590007251")),
+                Bytes::from(hex!(
+                    "0x0000000000000000000000000000000000000000000000000000000000000003"
+                )),
+                Bytes::from(hex!(
+                    "0x0000000000000000000000000000000000000000000000000000000000000001"
+                )),
+                Bytes::from(hex!(
+                    "0x0000000000000000000000000000000000000000000000000000000000000002"
+                )),
+                Bytes::from(hex!(
+                    "0x0000000000000000000000000000000000000000000000000000000000000000"
+                )),
+                Bytes::from(hex!("0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba")),
+                Bytes::from(hex!("0x0000000000000000000000000000000000001000")),
+                Bytes::from(hex!(
+                    "0x0000000000000000000000000000000000000000000000000000000000000002"
+                )),
+                Bytes::from(hex!(
+                    "0x0000000000000000000000000000000000000000000000000000000000000000"
+                )),
+                Bytes::from(hex!(
+                    "0x0000000000000000000000000000000000000000000000000000000000000001"
+                )),
+            ]
+            .to_vec()
+        };
+
+        let headers: Vec<Bytes> = {
+            [
+            Bytes::from(hex!("0xf90257a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a05e5fc7fb30faa5cdc163023c4ce2dc8807601ec858dd2905738dad824d0a21cea056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b901000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000080808402255100808000a0000000000000000000000000000000000000000000000000000000000000000088000000000000000007a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b4218080a00000000000000000000000000000000000000000000000000000000000000000a0e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
+        ].to_vec()
+        };
+
+        let pre_state_root: B256 = alloy_rlp::decode_exact::<Header>(headers.get(0).unwrap())
+            .unwrap()
+            .state_root
+            .clone();
+
+        let ew = ExecutionWitness {
+            state,
+            codes,
+            keys: keys.clone(),
+            headers,
+        };
+
+        let trie = SimpleSparseState::new(&ew, pre_state_root);
+        assert!(trie.is_ok(), "Error creating trie");
+        let mut trie = trie.unwrap();
+        // Verify root hash
+        assert_eq!(trie.0.state.hash(), pre_state_root);
+        assert_eq!(
+            trie.0
+                .calculate_state_root(HashedPostState::default())
+                .unwrap(),
+            pre_state_root
+        );
+
+        // Calculate post-state root. Change an account balance value and recalculate root hash.
+        let mut accounts = B256Map::<Option<Account>>::default();
+        let address = Address::from_slice(&hex!("0x00000961ef480eb55e80d19ad83579a64c007002"));
+        let a = trie.0.account(address).unwrap().unwrap();
+        accounts.insert(
+            keccak256(address),
+            Some(Account {
+                nonce: a.nonce,
+                balance: a.balance + U256::from(1),
+                bytecode_hash: Some(a.code_hash.clone()),
+            }),
+        );
+        let hashed_post_state = HashedPostState {
+            accounts,
+            storages: B256Map::default(),
+        };
+
+        println!(
+            "{}",
+            trie.0.calculate_state_root(hashed_post_state).unwrap()
+        );
+    }
+}

--- a/crates/simple-trie/Cargo.toml
+++ b/crates/simple-trie/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "simple-trie"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[dependencies]
+alloy-primitives = { version = "1.3", default-features = false }
+alloy-trie = { version = "0.8.0", default-features = false }
+alloy-rlp = { version = "0.3.8", default-features = false }
+
+[lints]
+workspace = true

--- a/crates/simple-trie/src/lib.rs
+++ b/crates/simple-trie/src/lib.rs
@@ -1,0 +1,7 @@
+//! A sparse Simple Merkle Patricia trie implementation.
+mod trie;
+
+pub use alloy_primitives::B256;
+pub use alloy_trie::Nibbles;
+pub use trie::B256Map;
+pub use trie::Trie;

--- a/crates/simple-trie/src/trie/children.rs
+++ b/crates/simple-trie/src/trie/children.rs
@@ -1,0 +1,73 @@
+//! Implementation of a 16-element branch node children array.
+//! It stores an additional bit flag indicating which child is not empty. Only for an optimization purpose
+use std::slice::{Iter, IterMut};
+use crate::trie::TrieNode;
+
+#[derive(Debug, Clone, Default)]
+pub(super) struct BranchNodeChildrenArray {
+    children: [Option<Box<TrieNode>>; 16],
+    flags: u16
+}
+
+impl BranchNodeChildrenArray {
+    #[inline]
+    pub(super) fn new() -> Self {
+        Self { children: [const { None }; 16], flags: 0 }
+    }
+
+    #[inline]
+    pub(super) fn get(&self, idx: usize) -> &Option<Box<TrieNode>> {
+        unsafe { self.children.get_unchecked(idx) }
+    }
+
+    #[inline]
+    pub(super) fn get_mut(&mut self, idx: usize) -> Option<&mut Box<TrieNode>> {
+        unsafe {
+            if let Some(child) = self.children.get_unchecked_mut(idx) {
+                Some(child)
+            } else {
+                None
+            }
+        }
+    }
+
+    #[inline]
+    pub(super) fn insert(&mut self, idx: usize, node: Box<TrieNode>) {
+        self.children[idx] = Some(node);
+        self.flags |= 1 << idx;
+    }
+
+    #[inline]
+    pub(super) fn remove(&mut self, idx: usize) {
+        self.children[idx] = None;
+        self.flags &= !(1 << idx);
+    }
+
+    #[inline]
+    pub(super) fn is_empty(&self) -> bool {
+        self.flags == 0
+    }
+
+    #[inline]
+    pub(super) fn one_child_left(&mut self) -> Option<(usize, &mut Box<TrieNode>)> {
+        if self.flags & (self.flags - 1) == 0 {
+            let idx = self.flags.trailing_zeros();
+            unsafe {
+                Some((idx as usize, self.children.get_unchecked_mut(idx as usize).as_mut().unwrap()))
+            }
+        } else {
+            None
+        }
+
+    }
+
+    #[inline]
+    pub(super) fn iter_mut(&mut self) -> IterMut<'_, Option<Box<TrieNode>>> {
+        self.children.iter_mut()
+    }
+
+    #[inline]
+    pub(super) fn iter(&self) -> Iter<'_, Option<Box<TrieNode>>> {
+        self.children.iter()
+    }
+}

--- a/crates/simple-trie/src/trie/display.rs
+++ b/crates/simple-trie/src/trie/display.rs
@@ -1,0 +1,47 @@
+//! Simple printing implementation of an MPT.
+use crate::trie::TrieNode::{Branch, Digest, Leaf};
+use crate::trie::{Trie, TrieNode};
+use std::fmt::Display;
+
+impl Display for Trie {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.root.is_none() {
+            return write!(f, "Trie {{ EMPTY }}");
+        }
+
+        fn fmt_node(
+            f: &mut std::fmt::Formatter<'_>,
+            node: &TrieNode,
+            indent: usize,
+        ) -> std::fmt::Result {
+            write!(f, "{}", " ".repeat(indent))?;
+            match node {
+                Branch(branch) => {
+                    write!(f, "Branch {:?}", branch.path.to_vec())?;
+                    for child in branch.children.iter() {
+                        if child.is_none() {
+                            write!(f, "\n{}None", " ".repeat(indent + 4))?;
+                        } else {
+                            write!(f, "\n")?;
+                            fmt_node(f, child.as_ref().unwrap(), indent + 4)?;
+                        }
+                    }
+                    Ok(())
+                }
+                Leaf(leaf) => write!(
+                    f,
+                    "Leaf {{ path: {:?}, value: {:?} }}",
+                    leaf.path.to_vec(),
+                    leaf.value
+                ),
+                Digest(digest) => write!(
+                    f,
+                    "Digest {{ path: {:?}, digest: {:?} }}",
+                    digest.path, digest.value
+                ),
+            }
+        }
+
+        fmt_node(f, &self.root.as_ref().unwrap(), 0)
+    }
+}

--- a/crates/simple-trie/src/trie/get.rs
+++ b/crates/simple-trie/src/trie/get.rs
@@ -1,0 +1,55 @@
+//! Implementation of getting an element from the MPT trie according to the element's path value.
+use crate::trie::TrieNode::{Branch, Digest, Leaf};
+use super::nodes::{BranchNode, DigestNode, LeafNode, TrieNode};
+use alloy_primitives::Bytes;
+use alloy_trie::Nibbles;
+
+impl LeafNode {
+    fn get(&self, path: Nibbles) -> Option<&Bytes> {
+        if self.path == path {
+            Some(&self.value)
+        } else {
+            None
+        }
+    }
+}
+
+impl BranchNode {
+    fn get(&self, path: Nibbles) -> Option<&Bytes> {
+        // It is only possible in case when the `self.path` is a prefix of `path`,
+        // otherwise return None.
+        let common_prefix_len = self.path.common_prefix_length(&path);
+        if common_prefix_len == self.path.len() {
+            if let Some(child) = self.children.get(path[common_prefix_len] as usize)
+            {
+                child.get(path.slice(common_prefix_len + 1..))
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl DigestNode {
+    fn get(&self, path: Nibbles) -> Option<&Bytes> {
+        // Disallow access to the digest node child, but allow when accessing a path which is
+        // a prefix of the digest node path.
+        if path.common_prefix_length(&self.path) < self.path.len() {
+            return None;
+        } else {
+            panic!("MPT: Unresolved node access")
+        }
+    }
+}
+
+impl TrieNode {
+    pub(super) fn get(&self, path: Nibbles) -> Option<&Bytes> {
+        match self {
+            Leaf(leaf) => leaf.get(path),
+            Branch(branch) => branch.get(path),
+            Digest(digest) => digest.get(path),
+        }
+    }
+}

--- a/crates/simple-trie/src/trie/hash.rs
+++ b/crates/simple-trie/src/trie/hash.rs
@@ -1,0 +1,345 @@
+//! Hashing element implementation for different node's types of MPT.
+use crate::trie::TrieNode::{Branch, Digest, Leaf};
+use crate::trie::rlp::encode_list_header;
+use super::nodes::{BranchNode, DigestNode, LeafNode, TrieNode};
+use alloy_primitives::private::alloy_rlp::Encodable;
+use alloy_primitives::{B256, keccak256};
+use alloy_trie::nodes::encode_path_leaf;
+
+impl TrieNode {
+    pub(super) fn hash(&mut self) -> B256 {
+        match self {
+            Leaf(leaf) => leaf.hash(),
+            Branch(branch) => branch.hash(),
+            Digest(digest) => digest.hash(),
+        }
+    }
+}
+
+impl LeafNode {
+    // Returns RLP encoding of the leaf node.
+    // https://ethereum.org/pl/developers/docs/data-structures-and-encoding/patricia-merkle-trie/#optimization
+    fn encode(&self) -> Vec<u8> {
+        // Encode the path of the leaf. It is not RLP encoding.
+        // It is encoding of the path according to
+        // https://ethereum.org/pl/developers/docs/data-structures-and-encoding/patricia-merkle-trie/#specification
+        let path = encode_path_leaf(&self.path, true);
+        // Prepare RLP encoded list header with a pre-allocated vector buffer.
+        // The list contains two elements, the encoded `path` and `value`
+        // Warning: `.length()` computes the *RLP* representation length of the value it is called on.
+        let mut out = encode_list_header(path.length() + self.value.length());
+
+        path.encode(&mut out);
+        self.value[..].encode(&mut out);
+        out
+    }
+
+    // Returns hash of the leaf node.
+    // Caches computed hash to avoid unnecessary recomputations.
+    fn hash(&mut self) -> B256 {
+        match self.hash {
+            Some(hash) => hash,
+            None => {
+                //keccak256(self.encode())
+                self.hash = Some(keccak256(self.encode()));
+                self.hash.unwrap()
+            }
+        }
+    }
+}
+
+impl BranchNode {
+    // Returns RLP encoding of the branch node.
+    // https://ethereum.org/pl/developers/docs/data-structures-and-encoding/patricia-merkle-trie/#optimization
+    fn encode(&mut self) -> Vec<u8> {
+        static EMPTY_NODE: u8 = 0x80;
+
+        let mut encoded: Vec<u8> = Vec::default();
+
+        for child in self.children.iter_mut() {
+            if let Some(child) = child {
+                match child.as_mut() {
+                    Leaf(leaf) => {
+                        encoded.append(&mut shorten_encoding(leaf.encode()));
+                    }
+                    _ => {
+                        child.hash()[..].encode(&mut encoded);
+                    }
+                }
+            } else {
+                encoded.push(EMPTY_NODE);
+            }
+        }
+
+        // Push an empty branch value.
+        encoded.push(EMPTY_NODE);
+
+        // TODO: Check performance of this appending
+        let mut encoded_branch = encode_list_header(encoded.len());
+        encoded_branch.append(&mut encoded);
+
+        if self.path.is_empty() {
+            encoded_branch
+        } else {
+            // In case when a branch has a path, return (the encoded path, hash of the branch encoding).
+            let encoded_path = encode_path_leaf(&self.path, false);
+            let mut encoded_branch_shortened = shorten_encoding(encoded_branch);
+
+            // `encoded_branch_shortened` is already encoded so we need to use absolut length (`.len()`)
+            // and append instead of encode.
+            // Warning: `.length()` computes the *RLP* representation length of the value it is called on.
+            let mut encoded_branch_with_path =
+                encode_list_header(encoded_path.length() + encoded_branch_shortened.len());
+
+            encoded_path.encode(&mut encoded_branch_with_path);
+            encoded_branch_with_path.append(&mut encoded_branch_shortened);
+            encoded_branch_with_path
+        }
+    }
+
+    // Returns hash of the branch node.
+    // Caches computed hash to avoid unnecessary recomputations.
+    fn hash(&mut self) -> B256 {
+        match self.hash {
+            Some(hash) => hash,
+            None => {
+                //keccak256(self.encode())
+                self.hash = Some(keccak256(self.encode()));
+                self.hash.unwrap()
+            }
+        }
+    }
+}
+
+impl DigestNode {
+    fn encode(&self) -> Vec<u8> {
+        if self.path.is_empty() {
+            // We use `encode` to calculate hash only, but the hash of the digest without a path
+            // is just its value. `encode` should never be used.
+            unreachable!()
+        } else {
+            let encoded_path = encode_path_leaf(&self.path, false);
+            let mut encoded_digest_with_path = encode_list_header(
+                encoded_path.length() + 33, /* encoded keccak256 value is always 33 bytes length */
+            );
+
+            encoded_path.encode(&mut encoded_digest_with_path);
+            self.value.encode(&mut encoded_digest_with_path);
+            encoded_digest_with_path
+        }
+    }
+
+    pub(super) fn hash(&mut self) -> B256 {
+        match self.hash {
+            Some(hash) => hash,
+            None => {
+                if self.path.is_empty() {
+                    // When the digest node has no path, its hash is equal to its value.
+                    self.hash = Some(self.value);
+                    self.value
+                } else {
+                    self.hash = Some(keccak256(self.encode()));
+                    self.hash.unwrap()
+                }
+            }
+        }
+    }
+}
+
+// Encodes a branch child node depending on the child data length.
+#[inline]
+fn shorten_encoding(b: Vec<u8>) -> Vec<u8> {
+    if b.len() < 32 {
+        b
+    } else {
+        let mut out: Vec<u8> = Vec::with_capacity(32);
+        keccak256(b).encode(&mut out);
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::trie::Trie;
+    use alloy_primitives::private::alloy_rlp::Encodable;
+    use alloy_primitives::{Bytes, hex, keccak256};
+    use alloy_trie::Nibbles;
+    use std::vec;
+
+    #[test]
+    fn test_leaf_node_example1() {
+        let mut trie = Trie::new();
+        trie.insert(Nibbles::unpack(hex!("010203")), Bytes::from("hello"));
+        assert_eq!(
+            trie.hash(),
+            hex!("82c8fd36022fbc91bd6b51580cfd941d3d9994017d59ab2e8293ae9c94c3ab6e")
+        );
+    }
+
+    #[test]
+    fn test_branch_node_example1() {
+        // A trie of single branch node and two leaf nodes with paths of length 2.
+        // The branch node has leaf nodes at positions [4] and [5].
+        // {4:1, 5:a}
+
+        let value1 = Bytes::from("v___________________________1");
+        let key1 = Nibbles::unpack(hex!("0x41"));
+        let path1 = [0x4u8, 0x1];
+        let encoded_path1 = vec![0x30u8 | path1[1]];
+        let mut leaf_node1 = vec![];
+        vec![Bytes::from(encoded_path1), value1.clone()].encode(&mut leaf_node1);
+        assert_eq!(
+            leaf_node1,
+            hex!("df319d765f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f31")
+        );
+
+        let value2 = Bytes::from("v___________________________2");
+        let key2 = Nibbles::unpack(hex!("0x5a"));
+        let path2 = [0x5u8, 0xa];
+        let encoded_path2 = vec![0x30u8 | path2[1]];
+        let mut leaf_node2 = vec![];
+        vec![Bytes::from(encoded_path2), value2.clone()].encode(&mut leaf_node2);
+        assert_eq!(
+            leaf_node2,
+            hex!("df3a9d765f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f32")
+        );
+
+        let mut trie = Trie::new();
+        trie.insert(key1, value1);
+        trie.insert(key2, value2);
+        assert_eq!(
+            trie.hash(),
+            hex!("1aaa6f712413b9a115730852323deb5f5d796c29151a60a1f55f41a25354cd26")
+        );
+    }
+
+    #[test]
+    fn test_branch_node_of_3() {
+        // A trie of single branch node and three leaf nodes with paths of length 2.
+        // The branch node has leaf nodes at positions [0], [1] and [2]. All leaves have path 0.
+        // {0:0 1:0 2:0}
+
+        let mut trie = Trie::new();
+        trie.insert(Nibbles::unpack(hex!("0x00")), Bytes::from("X"));
+        trie.insert(Nibbles::unpack(hex!("0x10")), Bytes::from("Y"));
+        trie.insert(Nibbles::unpack(hex!("0x20")), Bytes::from("Z"));
+        assert_eq!(
+            trie.hash(),
+            hex!("5c5154e8d108dcf8b9946c8d33730ec8178345ce9d36e6feed44f0134515482d")
+        );
+    }
+
+    #[test]
+    fn test_leaf_node_with_empty_path() {
+        // Both inserted leaves have empty path in the end.
+        // 0:{0:"X", 1:"Y"}
+        let mut trie = Trie::new();
+        trie.insert(Nibbles::unpack(hex!("0x00")), Bytes::from("X"));
+        trie.insert(Nibbles::unpack(hex!("0x01")), Bytes::from("Y"));
+        println!("{}", trie);
+        assert_eq!(
+            trie.hash(),
+            hex!("0a923005d10fbd4e571655cec425db7c5091db03c33891224073a55d3abc2415")
+        );
+    }
+
+    #[test]
+    fn test_extension_node_example1() {
+        // A trie of an extension node followed by a branch node with
+        // two leaves with single nibble paths.
+        // 5858:{4:1, 5:a}
+
+        let value1 = Bytes::from("v___________________________1");
+        let key1 = Nibbles::unpack(hex!("0x585841"));
+        let _path1 = [0x5u8, 0x8, 0x5, 0x8, 0x4, 0x1];
+
+        let value2 = Bytes::from("v___________________________2");
+        let key2 = Nibbles::unpack(hex!("0x58585a"));
+        let _path2 = [0x5u8, 0x8, 0x5, 0x8, 0x5, 0xa];
+
+        let encoded_common_path = vec![0x00u8, 0x58, 0x58];
+
+        // The hash of the branch node. See the branch_node_example test.
+        let branch_node_hash =
+            hex!("1aaa6f712413b9a115730852323deb5f5d796c29151a60a1f55f41a25354cd26");
+
+        let mut extension_node = vec![];
+        vec![
+            Bytes::from(encoded_common_path),
+            Bytes::from(branch_node_hash),
+        ]
+        .encode(&mut extension_node);
+        assert_eq!(
+            keccak256(extension_node),
+            hex!("3eefc183db443d44810b7d925684eb07256e691d5c9cb13215660107121454f9")
+        );
+
+        let mut trie = Trie::new();
+        trie.insert(key1, value1);
+        trie.insert(key2, value2);
+        assert_eq!(
+            trie.hash(),
+            hex!("3eefc183db443d44810b7d925684eb07256e691d5c9cb13215660107121454f9")
+        );
+    }
+
+    #[test]
+    fn test_extension_node_example2() {
+        // A trie of an extension node followed by a branch node with
+        // two leaves with longer paths.
+        // 585:{8:41, 9:5a}
+
+        let value1 = Bytes::from("v___________________________1");
+        let key1 = Nibbles::unpack(hex!("0x585841"));
+        let path1 = [0x5u8, 0x8, 0x5, 0x8, 0x4, 0x1];
+
+        let value2 = Bytes::from("v___________________________2");
+        let key2 = Nibbles::unpack(hex!("0x58595a"));
+        let path2 = [0x5u8, 0x8, 0x5, 0x9, 0x5, 0xa];
+
+        let common_path = [0x5u8, 0x8, 0x5];
+        let encoded_path1 = vec![0x20u8, ((path1[4] << 4) | path1[5])];
+        assert_eq!(hex::encode(&encoded_path1), "2041");
+        let encoded_path2 = vec![0x20u8, ((path2[4] << 4) | path2[5])];
+        assert_eq!(hex::encode(&encoded_path2), "205a");
+
+        let mut node1 = Vec::new();
+        vec![Bytes::from(encoded_path1), value1.clone()].encode(&mut node1);
+        assert_eq!(
+            hex::encode(&node1),
+            "e18220419d765f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f31"
+        );
+        let mut node2 = Vec::new();
+        vec![Bytes::from(encoded_path2), value2.clone()].encode(&mut node2);
+        assert_eq!(
+            hex::encode(&node2),
+            "e182205a9d765f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f5f32"
+        );
+
+        let branch_node_hash =
+            hex!("01746f8ab5a4cc5d6175cbd9ea9603357634ec06b2059f90710243f098e0ee82");
+
+        let encoded_common_path = vec![
+            0x10u8 | common_path[0],
+            ((common_path[1] << 4) | common_path[2]),
+        ];
+        let mut extension_node = Vec::new();
+        vec![
+            Bytes::from(encoded_common_path),
+            Bytes::from(branch_node_hash),
+        ]
+        .encode(&mut extension_node);
+        assert_eq!(
+            hex::encode(keccak256(extension_node)),
+            "ac28c08fa3ff1d0d2cc9a6423abb7af3f4dcc37aa2210727e7d3009a9b4a34e8"
+        );
+
+        let mut trie = Trie::new();
+        trie.insert(key1, value1);
+        trie.insert(key2, value2);
+        assert_eq!(
+            trie.hash(),
+            hex!("ac28c08fa3ff1d0d2cc9a6423abb7af3f4dcc37aa2210727e7d3009a9b4a34e8")
+        );
+    }
+}

--- a/crates/simple-trie/src/trie/hash.rs
+++ b/crates/simple-trie/src/trie/hash.rs
@@ -158,6 +158,7 @@ fn shorten_encoding(b: Vec<u8>) -> Vec<u8> {
     }
 }
 
+// Test cases from https://github.com/ipsilon/evmone/blob/31bf2116792032e572394e86cc99d6227e1e98b1/test/unittests/state_mpt_test.cpp#L59-L183
 #[cfg(test)]
 mod tests {
     use crate::trie::Trie;

--- a/crates/simple-trie/src/trie/insert.rs
+++ b/crates/simple-trie/src/trie/insert.rs
@@ -1,0 +1,143 @@
+//! Inserting an element to MPT implementation for different node's types.
+use crate::trie::TrieNode::{Branch, Digest, Leaf};
+use super::nodes::{BranchNode, DigestNode, LeafNode, TrieNode, BranchNodeChildrenArray};
+use alloy_primitives::Bytes;
+use alloy_trie::Nibbles;
+
+impl BranchNode {
+    fn new(
+        path: Nibbles,
+        child1_idx: usize,
+        child1: TrieNode,
+        child2_idx: usize,
+        child2: TrieNode,
+    ) -> Self {
+        let mut children = BranchNodeChildrenArray::new();
+        children.insert(child1_idx, Box::new(child1));
+        children.insert(child2_idx, Box::new(child2));
+        Self {
+            path,
+            children,
+            hash: None,
+        }
+    }
+
+    fn insert(&mut self, path: Nibbles, value: Bytes) {
+        let common_prefix_len = self.path.common_prefix_length(&path);
+
+        if common_prefix_len == self.path.len() {
+            // Add the new value to as a child of the branch node.
+            let new_idx = path.at(common_prefix_len);
+            let maybe_child = self.children.get_mut(new_idx);
+
+            match maybe_child {
+                Some(child) => {
+                    // If the child is not empty, recursively go into the branch. Consume the first
+                    // path nibble as it encodes the branch index.
+                    child.insert(path.slice(common_prefix_len + 1..), value);
+                    return;
+                }
+                None => {
+                    // If the index branch is empty, insert the new leaf there.
+                    let new_leaf = Leaf(LeafNode {
+                        path: path.slice(common_prefix_len + 1..),
+                        value,
+                        hash: None,
+                    });
+                    self.children.insert(new_idx, Box::new(new_leaf));
+                }
+            }
+        } else {
+            // Create a new branch node with a path equal to the common path.
+            // Attach the new leaf and current branch to the new branch node,
+            // adjusting the paths accordingly.
+            let current_digest_idx = self.path.at(common_prefix_len);
+            let new_leaf_idx = path.at(common_prefix_len);
+
+            *self = BranchNode::new(
+                path.slice(..common_prefix_len),
+                current_digest_idx,
+                Branch(BranchNode {
+                    path: self.path.slice(common_prefix_len + 1..),
+                    children: core::mem::take(&mut self.children),
+                    hash: None,
+                }),
+                new_leaf_idx,
+                Leaf(LeafNode {
+                    path: path.slice(common_prefix_len + 1..),
+                    value,
+                    hash: None,
+                }),
+            );
+        }
+    }
+}
+
+impl TrieNode {
+    pub(super) fn insert(&mut self, path: Nibbles, value: Bytes) {
+        self.clear_cache();
+        match self {
+            Leaf(leaf) => {
+                if path == leaf.path {
+                    // Override leaf node value.
+                    leaf.value = value;
+                } else {
+                    let common_prefix_len = leaf.path.common_prefix_length(&path);
+                    // Adding a leaf to a leaf node.
+                    // Create a new branch node with a path equal to the common path.
+                    // Attach the leaves to the new branch node adjusting the leaves' paths.
+                    let current_leaf_idx = leaf.path.at(common_prefix_len);
+                    let new_leaf_idx = path.at(common_prefix_len);
+
+                    *self = Branch(BranchNode::new(
+                        path.slice(..common_prefix_len),
+                        current_leaf_idx,
+                        Leaf(LeafNode {
+                            path: leaf.path.slice(common_prefix_len + 1..),
+                            value: core::mem::take(&mut leaf.value),
+                            hash: None,
+                        }),
+                        new_leaf_idx,
+                        Leaf(LeafNode {
+                            path: path.slice(common_prefix_len + 1..),
+                            value,
+                            hash: None,
+                        }),
+                    ));
+                }
+            }
+            Branch(branch) => {
+                branch.insert(path, value);
+            }
+            Digest(digest) => {
+                let common_prefix_len = path.common_prefix_length(&digest.path);
+                if common_prefix_len < digest.path.len() {
+                    // Create a new branch node with a path equal to the common path.
+                    // Attach the current node and the new node to the new branch adjusting their paths.
+                    let current_digest_idx = digest.path.at(common_prefix_len);
+                    let new_leaf_idx = path.at(common_prefix_len);
+
+                    *self = Branch(BranchNode::new(
+                        path.slice(..common_prefix_len),
+                        current_digest_idx,
+                        Digest(DigestNode {
+                            path: digest.path.slice(common_prefix_len + 1..),
+                            value: digest.value,
+                            hash: None,
+                        }),
+                        new_leaf_idx,
+                        Leaf(LeafNode {
+                            path: path.slice(common_prefix_len + 1..),
+                            value,
+                            hash: None,
+                        }),
+                    ));
+                    return;
+                } else {
+                    // Adding to an unresolved node is impossible.
+                    panic!("MPT: Unresolved node access");
+                }
+            }
+        }
+    }
+}

--- a/crates/simple-trie/src/trie/mod.rs
+++ b/crates/simple-trie/src/trie/mod.rs
@@ -1,0 +1,21 @@
+mod display;
+mod get;
+mod hash;
+mod insert;
+mod remove;
+mod reveal;
+mod rlp;
+mod trie;
+mod children;
+mod nodes;
+
+use std::fmt::Debug;
+use nodes::TrieNode;
+pub use trie::B256Map;
+
+
+/// Implements an Merkle Patricia Trie with 3 nodes' types (leaf, branch and digest)
+#[derive(Debug, Clone)]
+pub struct Trie {
+    root: Option<TrieNode>,
+}

--- a/crates/simple-trie/src/trie/nodes.rs
+++ b/crates/simple-trie/src/trie/nodes.rs
@@ -1,0 +1,36 @@
+//! Definition of 3 node's types building the trie.
+
+//! For optimization purpose and to simplify the implementation, we do not define an extension node.
+//! This additional node type is implemented by extending the branch and the digest nodes' types with a path parameter.
+//! It greatly simplifies the implementation of all trie modification and encoding algorithms.
+use alloy_primitives::{Bytes, B256};
+use crate::Nibbles;
+pub(super) use crate::trie::children::BranchNodeChildrenArray;
+
+#[derive(Debug, Clone)]
+pub(crate) struct BranchNode {
+    pub(crate) children: BranchNodeChildrenArray,
+    pub(crate) path: Nibbles,
+    pub(crate) hash: Option<B256>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LeafNode {
+    pub(crate) path: Nibbles,
+    pub(crate) value: Bytes,
+    pub(crate) hash: Option<B256>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DigestNode {
+    pub(crate) path: Nibbles,
+    pub(crate) value: B256,
+    pub(crate) hash: Option<B256>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum TrieNode {
+    Branch(BranchNode),
+    Leaf(LeafNode),
+    Digest(DigestNode),
+}

--- a/crates/simple-trie/src/trie/remove.rs
+++ b/crates/simple-trie/src/trie/remove.rs
@@ -1,0 +1,92 @@
+//! Removing an element from MPT implementation for different node's types.
+use crate::trie::TrieNode::{Branch, Digest, Leaf};
+use super::nodes::{BranchNode, LeafNode, TrieNode};
+use alloy_trie::Nibbles;
+
+impl BranchNode {
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.children.is_empty()
+    }
+
+    // Checks if the only child left in the branch node and returns its reference and its index.
+    #[inline]
+    fn only_one_child_left(&mut self) -> Option<(usize, &mut Box<TrieNode>)> {
+        self.children.one_child_left()
+    }
+
+    fn remove(&mut self, path: Nibbles) {
+        let common_prefix_len = self.path.common_prefix_length(&path);
+        if common_prefix_len == self.path.len() {
+            let idx = path.at(common_prefix_len);
+            let maybe_child = self.children.get_mut(idx);
+            match maybe_child {
+                Some(child) => {
+                    // Enter the child recursively
+                    child.remove(path.slice(common_prefix_len + 1..));
+                    // If the leaf is removed or the branch child is empty,
+                    // remove the child from the branch,
+                    match child.as_mut() {
+                        Leaf(leaf) => {
+                            if leaf.path == path.slice(common_prefix_len + 1..) {
+                                self.children.remove(idx);
+                            }
+                        }
+                        Branch(branch) => {
+                            if branch.is_empty() {
+                                self.children.remove(idx);
+                            }
+                        }
+                        Digest(_) => panic!("MPT: Unresolved node access"),
+                    }
+                }
+                None => {}
+            }
+        }
+    }
+}
+
+impl TrieNode {
+    pub(super) fn remove(&mut self, path: Nibbles) {
+        self.clear_cache();
+        match self {
+            Leaf(_) => {}
+            Branch(branch) => {
+                branch.remove(path);
+                // If only one child left in the branch:
+                // 1. Branch left -> prepend the parent path to the child branch. Remove parent.
+                // 2. Leaf left -> prepend the branch path to the leaf node path and replace the branch
+                // with the leaf.
+                let mut branch_path = branch.path.clone();
+                if let Some((child_idx, child)) = branch.only_one_child_left() {
+                    match child.as_mut() {
+                        Branch(child_branch) => {
+                            let mut new_path = core::mem::take(&mut branch_path);
+                            new_path.push_unchecked(child_idx as u8);
+                            new_path = new_path.join(&mut child_branch.path);
+
+                            *self = Branch(BranchNode {
+                                children: core::mem::take(&mut child_branch.children),
+                                path: new_path,
+                                hash: None,
+                            });
+                        }
+                        Leaf(child_leaf) => {
+                            let mut new_path = branch_path;
+                            new_path.push_unchecked(child_idx as u8);
+                            new_path = new_path.join(&mut child_leaf.path);
+
+                            *self = Leaf(LeafNode {
+                                path: new_path,
+                                value: core::mem::take(&mut child_leaf.value),
+                                hash: None,
+                            });
+                        }
+                        Digest(_) => panic!("MPT: Unresolved node access"),
+                    }
+                }
+            }
+            Digest(_) => panic!("MPT: Unresolved node access"),
+        }
+    }
+}

--- a/crates/simple-trie/src/trie/reveal.rs
+++ b/crates/simple-trie/src/trie/reveal.rs
@@ -1,0 +1,131 @@
+//! Building the MPT with the root hash and the trie nodes' values stored in a (hash)->(rlp encoded value) map.
+//! This implementation stores hash if the nodes in a simple caching mechanism which greatly optimizes a
+//! number of necessary hash calculations and node's rlp encodings.
+use crate::trie::B256Map;
+use crate::trie::TrieNode;
+use crate::trie::TrieNode::{Branch, Digest, Leaf};
+use alloy_primitives::{B256, Bytes};
+
+impl TrieNode {
+    fn set_cache(&mut self, hash: B256) {
+        match self {
+            Branch(branch) => {
+                branch.hash = Some(hash);
+            }
+            Leaf(leaf) => {
+                leaf.hash = Some(hash);
+            }
+            Digest(digest) => {
+                digest.hash = Some(hash);
+            }
+        };
+    }
+
+    pub(crate) fn clear_cache(&mut self) {
+        match self {
+            Branch(branch) => {
+                branch.hash = None;
+            }
+            Leaf(leaf) => {
+                leaf.hash = None;
+            }
+            Digest(digest) => {
+                digest.hash = None;
+            }
+        }
+    }
+}
+
+impl TrieNode {
+    pub(super) fn reveal(&mut self, rlp_rep_map: &B256Map<Bytes>) {
+        match self {
+            Leaf(_) => {}
+            Branch(branch) => {
+                for child in branch.children.iter_mut() {
+                    match child {
+                        Some(child) => {
+                            child.reveal(rlp_rep_map);
+                        }
+                        None => {}
+                    }
+                }
+            }
+            Digest(digest) => match rlp_rep_map.get(&digest.value) {
+                Some(rlp) => {
+                    let mut node = TrieNode::decode(&mut &rlp[..])
+                        .expect("MPT: Failed to decode trie node")
+                        .expect("MPT: Empty trie node");
+
+                    match node {
+                        Digest(ref digest_node) => {
+                            if digest_node.path.is_empty() {
+                                // The digest value does not reveal anything but the hash.
+                                return;
+                            }
+                        }
+                        Branch(ref mut branch) => {
+                            // The digest reveals to branch. Assign the digest's path to the branch.
+                            branch.path = core::mem::take(&mut digest.path);
+                        }
+                        Leaf(_) => {}
+                    }
+
+                    // Set cache based on the hash of the digest node which reveals to non-digest or
+                    // digest with a non-empty path. At this moment the digest hash should be cached.
+                    node.set_cache(digest.hash());
+                    node.reveal(rlp_rep_map);
+                    *self = node;
+                }
+                None => {}
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::trie::Trie;
+    use alloy_primitives::{hex, keccak256};
+    use alloy_trie::Nibbles;
+
+    #[test]
+    fn reveal_from_rlp() {
+        let state: Vec<Bytes> = {
+            [
+            Bytes::from(hex!("0xf869a0206aea581b220579a2b99819299dd32c7c28a420018ecb0bde93af007ad89a31b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a078c6cb5202685228bbcbfb992b1c4e116c7ec5ef11e25b8e92716cfc628ddd60")),
+            Bytes::from(hex!("0xf869a037d65eaa92c6bc4c13a5ec45527f0c18ea8932588728769ec7aecfe6d9f32e42b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0f57acd40259872606d76197ef052f3d35588dadf919ee1f0e3cb9b62d3f4b02c")),
+            Bytes::from(hex!("0xf8b1a0c4b823e1deb537a6b4c41ecc9123e37753d61894f9dee7022b29c83088f69cfba00d1c2f6add00c6786d64a77d4136f71ef02f4a69307c77b663f32875ae8c7d9780a066a64e47bae97c0fccdc260c76b1c987c89560cb40e86ea17a1d5fd49e35bebe8080a039e4714d1eb6e1d5b21ca2bffd56333a7cd697596ff64317d1ae21ffd048e6ca808080808080a008be39f7c15cc06a7d863615397887281eadcbdb7907665d0683ca3c6383e6b0808080")),
+            Bytes::from(hex!("0xf869a03f86c581c7d7b44eecbb92fd9e5867945ec1acdc0ea5bbabda21d17dddf06473b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a00345a365d2f4c5975b9f1599abe0a2ee76b7a3a731bc68781bd04c84e4858f50")),
+            Bytes::from(hex!("0xf869a03d7dcb6a0ce5227c5379fc5b0e004561d7833b063355f69bfea3178f08fbaab4b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a09fb907ad9cb2872884a1e6839fcf89d229ef9b43df0511f58dbb26a1217ecb0d")),
+            Bytes::from(hex!("0xf851808080a0de090f75dbe520ac527f21140ede3807a7dc416a0bae24c33dde9fe04300a08c808080808080808080a0f215e6bc9ca85972bc2488943dca80313a019f5eb569cc6ee3dc8c2af68734af808080")),
+            Bytes::from(hex!("0x80")),
+            Bytes::from(hex!("0xf851808080808080808080808080a031357c4a138624e300159fc631211a29d8373db4bdf59b80dad6e816593d0bcb8080a0b5790ff14363bee5d40c4a9fd9d6a515fc44683cc4d46666b4d9c775dded101780")),
+            Bytes::from(hex!("0xf871a020601462093b5945d1676df093446790fd31b20e7b12a2e8e5e09d068109616bb84ef84c80880de0b6b3a7640000a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")),
+            Bytes::from(hex!("0xf869a0209d57be05dd69371c4dd2e871bce6e9f4124236825bb612ee18a45e5675be51b846f8440180a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a06e49e66782037c0555897870e29fa5e552daf4719552131a0abce779daec0a5d"))
+        ].to_vec()
+        };
+
+        let rlp_map: B256Map<Bytes> = state
+            .iter()
+            .map(|rlp| (keccak256(&rlp), rlp.clone()))
+            .collect();
+        let root_hash = B256::from(hex!(
+            "0x5e5fc7fb30faa5cdc163023c4ce2dc8807601ec858dd2905738dad824d0a21ce"
+        ));
+
+        let mut trie = Trie::reveal_from_rlp(root_hash, &rlp_map);
+        assert_eq!(trie.hash(), root_hash);
+
+        let to_remove = Nibbles::from_nibbles([
+            0, 3, 6, 0, 1, 4, 6, 2, 0, 9, 3, 11, 5, 9, 4, 5, 13, 1, 6, 7, 6, 13, 15, 0, 9, 3, 4, 4,
+            6, 7, 9, 0, 15, 13, 3, 1, 11, 2, 0, 14, 7, 11, 1, 2, 10, 2, 14, 8, 14, 5, 14, 0, 9, 13,
+            0, 6, 8, 1, 0, 9, 6, 1, 6, 11,
+        ]);
+        trie.remove(to_remove.to_owned());
+        assert_ne!(trie.hash(), root_hash);
+
+        trie.insert(to_remove, Bytes::from(hex!("0xf84c80880de0b6b3a7640000a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")));
+        assert_eq!(trie.hash(), root_hash);
+    }
+}

--- a/crates/simple-trie/src/trie/rlp.rs
+++ b/crates/simple-trie/src/trie/rlp.rs
@@ -1,0 +1,115 @@
+//! Implementation of a trie node rlp decoding.
+//! Based on the implementation in the ` mpt ` module of this crate.
+use crate::trie::TrieNode::{Branch, Digest, Leaf};
+use super::nodes::{BranchNode, BranchNodeChildrenArray, DigestNode, LeafNode, TrieNode};
+use alloy_primitives::{B256, Bytes};
+use alloy_rlp::{Decodable, EMPTY_STRING_CODE, Header, PayloadView};
+use alloy_trie::Nibbles;
+
+impl TrieNode {
+    pub(super) fn decode(rlp_rep: &mut &[u8]) -> Result<Option<Self>, alloy_rlp::Error> {
+        match Header::decode_raw(rlp_rep)? {
+            PayloadView::String(payload) => {
+                if payload.is_empty() {
+                    Ok(None)
+                } else if payload.len() == 32 {
+                    Ok(Some(Digest(DigestNode {
+                        value: B256::from_slice(payload),
+                        hash: None,
+                        path: Nibbles::default(),
+                    })))
+                } else {
+                    Err(alloy_rlp::Error::Custom("MPT: Invalid RLP string length"))
+                }
+            }
+            PayloadView::List(list) => {
+                if list.len() == 17 {
+                    let mut children = BranchNodeChildrenArray::new();
+                    for (idx, element) in list[..16].iter().enumerate() {
+                        if *element != &[EMPTY_STRING_CODE] {
+                            let mut element_ref = element.as_ref();
+                            children.insert(idx, Box::new(
+                                TrieNode::decode(&mut element_ref)?
+                                    .expect("MPT: Unable to decode branch child node."),
+                            ));
+                        }
+                    }
+                    if list[16] != &[EMPTY_STRING_CODE] {
+                        return Err(alloy_rlp::Error::Custom(
+                            "MPT: Value in a branch node.",
+                        ));
+                    }
+                    Ok(Some(Branch(BranchNode {
+                        children,
+                        hash: None,
+                        path: Nibbles::default(),
+                    })))
+                } else if list.len() == 2 {
+                    let [encoded_path, value] = list.as_slice() else {
+                        unreachable!()
+                    };
+                    let mut encoded_path_ref = encoded_path.as_ref();
+                    let (path, is_leaf) = decode_path(&mut encoded_path_ref)?;
+                    if is_leaf {
+                        let mut value_ref = value.as_ref();
+                        Ok(Some(Leaf(LeafNode {
+                            path,
+                            value: Bytes::decode(&mut value_ref)?,
+                            hash: None,
+                        })))
+                    } else {
+                        let mut value_ref = value.as_ref();
+                        let mut node = TrieNode::decode(&mut value_ref)?
+                            .expect("MPT: Empty node in extension.");
+                        match &mut node {
+                            Branch(branch) => branch.path = path,
+                            Digest(digest) => digest.path = path,
+                            _ => {
+                                return Err(alloy_rlp::Error::Custom(
+                                    "MPT: Invalid extension node.",
+                                ));
+                            }
+                        }
+                        Ok(Some(node))
+                    }
+                } else {
+                    Err(alloy_rlp::Error::Custom("MPT: Invalid RLP list length"))
+                }
+            }
+        }
+    }
+}
+
+#[inline]
+fn decode_path(buf: &mut &[u8]) -> alloy_rlp::Result<(Nibbles, bool)> {
+    let path = Nibbles::unpack(Header::decode_bytes(buf, false)?);
+    if path.len() < 2 {
+        return Err(alloy_rlp::Error::InputTooShort);
+    }
+    let (is_leaf, odd_nibbles) = match path.at(0) {
+        0b0000 => (false, false),
+        0b0001 => (false, true),
+        0b0010 => (true, false),
+        0b0011 => (true, true),
+        _ => return Err(alloy_rlp::Error::Custom("node is not an extension or leaf")),
+    };
+    let path = if odd_nibbles {
+        path.slice(1..)
+    } else {
+        path.slice(2..)
+    };
+    Ok((path, is_leaf))
+}
+
+// Encodes list header for known payload length. Reserves memory.
+#[inline]
+pub(super) fn encode_list_header(payload_length: usize) -> Vec<u8> {
+    debug_assert!(payload_length > 1);
+    let header = Header {
+        list: true,
+        payload_length,
+    };
+    let mut out = Vec::with_capacity(header.length() + payload_length);
+    header.encode(&mut out);
+    out
+}

--- a/crates/simple-trie/src/trie/trie.rs
+++ b/crates/simple-trie/src/trie/trie.rs
@@ -1,0 +1,286 @@
+//! Implementation of the simple MPT.
+use crate::trie::TrieNode::{Digest, Leaf};
+use crate::trie::Trie;
+use super::nodes::{DigestNode, LeafNode};
+use alloy_primitives::map::{FbBuildHasher, HashMap};
+use alloy_primitives::{B256, Bytes};
+use alloy_trie::{EMPTY_ROOT_HASH, Nibbles};
+
+/// Added only to make an IDE happy. It is defined in alloy_primitives::map
+pub type B256Map<V> = HashMap<B256, V, FbBuildHasher<32>>;
+
+impl Trie {
+    /// Creates empty trie.
+    pub fn new() -> Self {
+        Self { root: None }
+    }
+
+    /// Inserts a value under the `path` key. Overrides previous values if exists.
+    pub fn insert(&mut self, path: Nibbles, value: Bytes) {
+        match self.root.as_mut() {
+            Some(root) => root.insert(path, value),
+            None => {
+                self.root = Some(Leaf(LeafNode {
+                    path,
+                    value,
+                    hash: None,
+                }))
+            }
+        }
+    }
+
+    /// Gets a value assosiated with a `path` key
+    pub fn get(&self, path: Nibbles) -> Option<&Bytes> {
+        if self.root.is_none() {
+            None
+        } else {
+            self.root.as_ref().unwrap().get(path)
+        }
+    }
+
+    /// Returns a root hash of the trie
+    pub fn hash(&mut self) -> B256 {
+        match self.root.as_mut() {
+            Some(root) => root.hash(),
+            None => EMPTY_ROOT_HASH,
+        }
+    }
+
+    /// Removes an element from the trie. If the element does not exist, it does nothing.
+    pub fn remove(&mut self, path: Nibbles) {
+        match self.root.as_mut() {
+            Some(root) => match root {
+                Leaf(leaf) => {
+                    if path.eq(&leaf.path) {
+                        self.root = None;
+                    }
+                }
+                _ => root.remove(path),
+            },
+            None => return,
+        }
+    }
+
+    /// Build a trie according to elements encoded in a hash->value map starting from the `root_hash`
+    pub fn reveal_from_rlp(root_hash: B256, rlp_rep_map: &B256Map<Bytes>) -> Self {
+        let mut trie = Trie::new();
+        if root_hash == EMPTY_ROOT_HASH {
+            return trie;
+        }
+        trie.root = Some(Digest(DigestNode {
+            value: root_hash,
+            hash: Some(root_hash),
+            path: Nibbles::default(),
+        }));
+        trie.root.as_mut().unwrap().reveal(rlp_rep_map);
+        trie
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{Bytes, hex};
+    use alloy_trie::Nibbles;
+
+    #[test]
+    fn basic_and_extension_node_test() {
+        let mut trie = Trie::new();
+        trie.insert(
+            Nibbles::unpack(hex!("0x12343123").to_vec()),
+            Bytes::from([1, 2, 3, 4, 3, 1, 2, 3]),
+        );
+        trie.insert(
+            Nibbles::unpack(hex!("0x12353123").to_vec()),
+            Bytes::from([1, 2, 3, 5, 3, 1, 2, 3]),
+        );
+        trie.insert(
+            Nibbles::unpack(hex!("0x12354123").to_vec()),
+            Bytes::from([1, 2, 3, 5, 4, 1, 2, 3]),
+        );
+        trie.insert(
+            Nibbles::unpack(hex!("0x12343223").to_vec()),
+            Bytes::from([1, 2, 3, 4, 3, 2, 2, 3]),
+        );
+        trie.insert(
+            Nibbles::unpack(hex!("0x12343023").to_vec()),
+            Bytes::from([1, 2, 3, 4, 3, 0, 2, 3]),
+        );
+        // Add to top of an extension node. Common prefix is empty.
+        trie.insert(
+            Nibbles::unpack(hex!("0x22343223").to_vec()),
+            Bytes::from([2, 2, 3, 4, 3, 2, 2, 3]),
+        );
+        // Add to an extension node. The extension node path reminder length is 1.
+        trie.insert(
+            Nibbles::unpack(hex!("0x12743223").to_vec()),
+            Bytes::from([1, 2, 7, 4, 3, 2, 2, 3]),
+        );
+        // Add to an extension node. The extension node path length is 1.
+        trie.insert(
+            Nibbles::unpack(hex!("0x12345223").to_vec()),
+            Bytes::from([1, 2, 3, 4, 5, 2, 2, 3]),
+        );
+
+        assert_eq!(
+            *trie
+                .get(Nibbles::unpack(hex!("0x12343123").to_vec()))
+                .unwrap(),
+            Bytes::from([1, 2, 3, 4, 3, 1, 2, 3])
+        );
+        assert_eq!(
+            *trie
+                .get(Nibbles::unpack(hex!("0x12353123").to_vec()))
+                .unwrap(),
+            Bytes::from([1, 2, 3, 5, 3, 1, 2, 3])
+        );
+        assert_eq!(
+            *trie
+                .get(Nibbles::unpack(hex!("0x12354123").to_vec()))
+                .unwrap(),
+            Bytes::from([1, 2, 3, 5, 4, 1, 2, 3])
+        );
+        assert_eq!(
+            *trie
+                .get(Nibbles::unpack(hex!("0x12343223").to_vec()))
+                .unwrap(),
+            Bytes::from([1, 2, 3, 4, 3, 2, 2, 3])
+        );
+        assert_eq!(
+            *trie
+                .get(Nibbles::unpack(hex!("0x12343023").to_vec()))
+                .unwrap(),
+            Bytes::from([1, 2, 3, 4, 3, 0, 2, 3])
+        );
+        assert_eq!(
+            *trie
+                .get(Nibbles::unpack(hex!("0x22343223").to_vec()))
+                .unwrap(),
+            Bytes::from([2, 2, 3, 4, 3, 2, 2, 3])
+        );
+        assert_eq!(
+            *trie
+                .get(Nibbles::unpack(hex!("0x12743223").to_vec()))
+                .unwrap(),
+            Bytes::from([1, 2, 7, 4, 3, 2, 2, 3])
+        );
+        assert_eq!(
+            *trie
+                .get(Nibbles::unpack(hex!("0x12345223").to_vec()))
+                .unwrap(),
+            Bytes::from([1, 2, 3, 4, 5, 2, 2, 3])
+        );
+    }
+
+    #[test]
+    fn basic_and_extension_node_middle_path_test() {
+        let mut trie = Trie::new();
+        trie.insert(
+            Nibbles::unpack(hex!("0x12343123").to_vec()),
+            Bytes::from([1, 2, 3, 4, 3, 1, 2, 3]),
+        );
+        trie.insert(
+            Nibbles::unpack(hex!("0x12353123").to_vec()),
+            Bytes::from([1, 2, 3, 5, 3, 1, 2, 3]),
+        );
+        trie.insert(
+            Nibbles::unpack(hex!("0x12354123").to_vec()),
+            Bytes::from([1, 2, 3, 5, 4, 1, 2, 3]),
+        );
+        trie.insert(
+            Nibbles::unpack(hex!("0x12343223").to_vec()),
+            Bytes::from([1, 2, 3, 4, 3, 2, 2, 3]),
+        );
+        // Add to an extension node in the middle of the exstension node path.
+        trie.insert(
+            Nibbles::unpack(hex!("0x11343223").to_vec()),
+            Bytes::from([1, 1, 3, 4, 3, 2, 2, 3]),
+        );
+
+        assert_eq!(
+            *trie
+                .get(Nibbles::unpack(hex!("0x12343123").to_vec()))
+                .unwrap(),
+            Bytes::from([1, 2, 3, 4, 3, 1, 2, 3])
+        );
+        assert_eq!(
+            *trie
+                .get(Nibbles::unpack(hex!("0x12353123").to_vec()))
+                .unwrap(),
+            Bytes::from([1, 2, 3, 5, 3, 1, 2, 3])
+        );
+        assert_eq!(
+            *trie
+                .get(Nibbles::unpack(hex!("0x12354123").to_vec()))
+                .unwrap(),
+            Bytes::from([1, 2, 3, 5, 4, 1, 2, 3])
+        );
+        assert_eq!(
+            *trie
+                .get(Nibbles::unpack(hex!("0x12343223").to_vec()))
+                .unwrap(),
+            Bytes::from([1, 2, 3, 4, 3, 2, 2, 3])
+        );
+        assert_eq!(
+            *trie
+                .get(Nibbles::unpack(hex!("0x11343223").to_vec()))
+                .unwrap(),
+            Bytes::from([1, 1, 3, 4, 3, 2, 2, 3])
+        );
+        // Override the value of the extension node.
+        trie.insert(
+            Nibbles::unpack(hex!("0x11343223").to_vec()),
+            Bytes::from([1, 1, 3, 4, 3, 2, 2, 9]),
+        );
+        assert_eq!(
+            *trie
+                .get(Nibbles::unpack(hex!("0x11343223").to_vec()))
+                .unwrap(),
+            Bytes::from([1, 1, 3, 4, 3, 2, 2, 9])
+        );
+    }
+
+    #[test]
+    fn remove_test() {
+        let mut trie = Trie::new();
+        trie.insert(
+            Nibbles::unpack(hex!("0x12343123").to_vec()),
+            Bytes::from([1, 2, 3, 4, 3, 1, 2, 3]),
+        );
+        trie.insert(
+            Nibbles::unpack(hex!("0x12353123").to_vec()),
+            Bytes::from([1, 2, 3, 5, 3, 1, 2, 3]),
+        );
+        trie.insert(
+            Nibbles::unpack(hex!("0x12354123").to_vec()),
+            Bytes::from([1, 2, 3, 5, 4, 1, 2, 3]),
+        );
+        trie.insert(
+            Nibbles::unpack(hex!("0x12343223").to_vec()),
+            Bytes::from([1, 2, 3, 4, 3, 2, 2, 3]),
+        );
+        trie.insert(
+            Nibbles::unpack(hex!("0x12343023").to_vec()),
+            Bytes::from([1, 2, 3, 4, 3, 0, 2, 3]),
+        );
+
+        println!("{}", trie);
+        trie.remove(Nibbles::unpack(hex!("0x12343123").to_vec()));
+        assert_eq!(trie.get(Nibbles::unpack(hex!("0x12343123").to_vec())), None);
+        println!("{}", trie);
+        trie.remove(Nibbles::unpack(hex!("0x12353123").to_vec()));
+        assert_eq!(trie.get(Nibbles::unpack(hex!("0x12353123").to_vec())), None);
+        println!("{}", trie);
+        trie.remove(Nibbles::unpack(hex!("0x12354123").to_vec()));
+        assert_eq!(trie.get(Nibbles::unpack(hex!("0x12354123").to_vec())), None);
+        println!("{}", trie);
+        trie.remove(Nibbles::unpack(hex!("0x12343223").to_vec()));
+        assert_eq!(trie.get(Nibbles::unpack(hex!("0x12343223").to_vec())), None);
+        println!("{}", trie);
+        trie.remove(Nibbles::unpack(hex!("0x12343023").to_vec()));
+        assert_eq!(trie.get(Nibbles::unpack(hex!("0x12343023").to_vec())), None);
+        println!("{}", trie);
+        // TODO: Change it when hash implementation is done.
+        assert_eq!(trie.to_string(), "Trie { EMPTY }");
+    }
+}


### PR DESCRIPTION
This PR implements a simple version of the Merkel Patricia Trie.
The implementation has a very similar efficiency to the zeth implementation (Benchmark on CPU. Not on a zkvm yet), but it's significantly faster than reth implementation. 

Comparison to zeth:
- Simpler code
- Similar efficiency.
- Does not use extension node type.


Benchmark runs the stateless validation of the main net block number `23439901`.
```
cmd: cargo run --release rpc_block_23439901.json

61.836084ms ---- reth
56.165083ms ---- zeth
--------
56.83225ms ---- simple
```

Additional comment:
This PR moves also dependency definition of the `sparsestate` implementation to the workspace to make sure we are using the same dependencies for both implementations.